### PR TITLE
crypt32: Strictly honor NULL parm in CryptBinaryToStringW

### DIFF
--- a/dlls/crypt32/base64.c
+++ b/dlls/crypt32/base64.c
@@ -304,13 +304,16 @@ static LONG encodeBase64W(const BYTE *in_buf, int in_len, LPCWSTR sep,
     needed = bytes + pad_bytes + 1;
     needed += (needed / 64 + 1) * strlenW(sep);
 
-    if (needed > *out_len)
-    {
+
+    if (out_buf == NULL) {
         *out_len = needed;
-        return ERROR_INSUFFICIENT_BUFFER;
+        return ERROR_SUCCESS;
     }
-    else
-        *out_len = needed;
+
+    if (needed > *out_len)
+        return ERROR_INSUFFICIENT_BUFFER;
+
+    *out_len = needed;
 
     /* Three bytes of input give 4 chars of output */
     div = in_len / 3;
@@ -409,6 +412,10 @@ static BOOL BinaryToBase64W(const BYTE *pbBinary,
         charsNeeded += strlenW(header) + strlenW(sep);
     if (trailer)
         charsNeeded += strlenW(trailer) + strlenW(sep);
+    if (pszString == NULL) {
+        *pcchString = charsNeeded - 1;
+        return ERROR_SUCCESS;
+    }
     if (charsNeeded <= *pcchString)
     {
         LPWSTR ptr = pszString;
@@ -431,14 +438,12 @@ static BOOL BinaryToBase64W(const BYTE *pbBinary,
         }
         *pcchString = charsNeeded - 1;
     }
-    else if (pszString)
+    else
     {
         *pcchString = charsNeeded;
         SetLastError(ERROR_INSUFFICIENT_BUFFER);
         ret = FALSE;
     }
-    else
-        *pcchString = charsNeeded;
     return ret;
 }
 


### PR DESCRIPTION
This fixes the segfault issue in ValveSoftware/Proton#298. I need to wait for the wine-devel mailing list administrator to approve my request to join the mailing list before I can send the patch upstream and I wnat to get this fixed in Proton sooner, rather than later, so I am submitting it here first.