### PR TITLE
apply wininet-InternetCrackUrlW from wine-staging

### DIFF
--- a/dlls/wininet/internet.c
+++ b/dlls/wininet/internet.c
@@ -1661,7 +1661,7 @@ BOOL WINAPI InternetCrackUrlW(const WCHAR *lpszUrl, DWORD dwUrlLength, DWORD dwF
 
     if (dwFlags & ICU_DECODE)
     {
-        WCHAR *url_tmp;
+        WCHAR *url_tmp, *buffer;
         DWORD len = dwUrlLength + 1;
         BOOL ret;
 
@@ -1670,9 +1670,24 @@ BOOL WINAPI InternetCrackUrlW(const WCHAR *lpszUrl, DWORD dwUrlLength, DWORD dwF
             SetLastError(ERROR_OUTOFMEMORY);
             return FALSE;
         }
-        ret = InternetCanonicalizeUrlW(url_tmp, url_tmp, &len, ICU_DECODE | ICU_NO_ENCODE);
+
+        buffer = url_tmp;
+        ret = InternetCanonicalizeUrlW(url_tmp, buffer, &len, ICU_DECODE | ICU_NO_ENCODE);
+        if (!ret && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+        {
+            buffer = heap_alloc(len * sizeof(WCHAR));
+            if (!buffer)
+            {
+                SetLastError(ERROR_OUTOFMEMORY);
+                heap_free(url_tmp);
+                return FALSE;
+            }
+            ret = InternetCanonicalizeUrlW(url_tmp, buffer, &len, ICU_DECODE | ICU_NO_ENCODE);
+        }
         if (ret)
-            ret = InternetCrackUrlW(url_tmp, len, dwFlags & ~ICU_DECODE, lpUC);
+            ret = InternetCrackUrlW(buffer, len, dwFlags & ~ICU_DECODE, lpUC);
+
+        if (buffer != url_tmp) heap_free(buffer);
         heap_free(url_tmp);
         return ret;
     }

--- a/dlls/wininet/tests/url.c
+++ b/dlls/wininet/tests/url.c
@@ -816,9 +816,9 @@ static void InternetCrackUrlW_test(void)
     comp.lpszUrlPath = urlpart;
     comp.dwUrlPathLength = sizeof(urlpart)/sizeof(urlpart[0]);
     r = InternetCrackUrlW(url3, 0, ICU_DECODE, &comp);
-    todo_wine ok(r, "InternetCrackUrlW failed unexpectedly\n");
-    todo_wine ok(!strcmp_wa(host, "x.org"), "host is %s, should be x.org\n", wine_dbgstr_w(host));
-    ok(urlpart[0] == 0, "urlpart should be empty\n");
+    ok(r, "InternetCrackUrlW failed unexpectedly\n");
+    ok(!strcmp_wa(host, "x.org"), "host is %s, should be x.org\n", wine_dbgstr_w(host));
+    todo_wine ok(urlpart[0] == 0, "urlpart should be empty\n");
 }
 
 static void fill_url_components(URL_COMPONENTSA *lpUrlComponents)


### PR DESCRIPTION
Warframe cannot reach it's content update servers without this patch. Both the launcher and the game itself need this patch. The game will crash without this on launching due to not being able to access content servers. Fixes bug: [40598] Resize buffer when call to InternetCanonicalizeUrlW fails in InternetCrackUrlW on winehq