### PR TITLE
Give userspace 3GB of address space

### DIFF
--- a/libs/wine/mmap.c
+++ b/libs/wine/mmap.c
@@ -350,7 +350,7 @@ void mmap_init(void)
     struct list *ptr;
     char stack;
     char * const stack_ptr = &stack;
-    char *user_space_limit = (char *)0x7ffe0000;
+    char *user_space_limit = (char *)0xbffe0000;
 
     reserve_malloc_space( 8 * 1024 * 1024 );
 


### PR DESCRIPTION
This patch is a one-liner from here:

https://startux.de/wine-patch-to-use-3gb-userspace.html

It is fairly old, but it allows userspace program to use up to 3GB of
RAM instead of 2GB of RAM. As the blog post says, this differs from the
Windows behavior, but apparently, Microsoft's own advice to developers
is to give userspace programs access to 4GB of address space on 64-bit
Windows:

https://blogs.msdn.microsoft.com/oldnewthing/20050601-24/?p=35483

Changing the restriction to 3GB of address space should be okay. I
suspect that upstream Wine won't like this change, but it should be fine
for proton. It would probably help DXVK.

Signed-off-by: Richard Yao <ryao@gentoo.org>