### PR TITLE
Fix fullscreen mouse clipping

### DIFF
--- a/dlls/winex11.drv/mouse.c
+++ b/dlls/winex11.drv/mouse.c
@@ -1539,12 +1539,12 @@ BOOL CDECL X11DRV_ClipCursor( LPCRECT clip )
             }
             else if (grab_clipping_window( clip )) return TRUE;
         }
-        else /* if currently clipping, check if we should switch to fullscreen clipping */
+        else /* check if we should switch to fullscreen clipping */
         {
             struct x11drv_thread_data *data = x11drv_thread_data();
-            if (data && data->clip_hwnd)
+            if (data)
             {
-                if (EqualRect( clip, &clip_rect ) || clip_fullscreen_window( foreground, TRUE ))
+                if ((data->clip_hwnd && EqualRect( clip, &clip_rect )) || clip_fullscreen_window( foreground, TRUE ))
                     return TRUE;
             }
         }

--- a/dlls/winex11.drv/mouse.c
+++ b/dlls/winex11.drv/mouse.c
@@ -551,8 +551,10 @@ BOOL clip_fullscreen_window( HWND hwnd, BOOL reset )
     release_win_data( data );
     if (!fullscreen) return FALSE;
     if (!(thread_data = x11drv_thread_data())) return FALSE;
-    if (GetTickCount() - thread_data->clip_reset < 1000) return FALSE;
-    if (!reset && clipping_cursor && thread_data->clip_hwnd) return FALSE;  /* already clipping */
+    if (!reset) {
+        if (GetTickCount() - thread_data->clip_reset < 1000) return FALSE;
+        if (clipping_cursor && thread_data->clip_hwnd) return FALSE;  /* already clipping */
+    }
     rect = get_primary_monitor_rect();
     if (!grab_fullscreen)
     {


### PR DESCRIPTION
A lot of users, including me, has an issue with a "mouse wall": if you move a mouse in one direction the camera eventually stops moving [[1]](https://github.com/ValveSoftware/Proton/issues/1418#issuecomment-420931532), [[2]](https://github.com/ValveSoftware/Proton/issues/832#issuecomment-420843944), [[3]](https://github.com/ValveSoftware/Proton/issues/579#issue-354033647). This happens because the pointer is not always successfully clipped in the fullscreen mode.

An important thing to understand is that [wine clips fullscreen windows automatically](https://github.com/ValveSoftware/wine/commit/a59c7cc8596b658d3c0854a737528cf60947ac1f) and, if the automatic procedure fails, an application will not be able to clip the mouse to the whole fullscreen window by calling ClipCursor.

The first three patches are fixes for the automatic fullscreen window clipping:
* If the screen mode changes rapidly, the mouse is not clipped
* The fs hack may break the fullscreen window detection when the resolution changes
* Unlike dxvk, wined3d does not trigger [a desktop resize event](https://github.com/ValveSoftware/wine/blob/58025614384053e61f1983a90f81135288f7e08e/dlls/winex11.drv/desktop.c#L323) when playing at the native resolution 

Those three patches alone fix the mouse clipping for me. I also include another one that changes ClipCursor behaviour so it activates the fullscreen clipping even if the automatic procedure has failed for some reason. I am not sure why it does not do it in the first place but I think it may be related to [this](https://github.com/ValveSoftware/wine/blob/58025614384053e61f1983a90f81135288f7e08e/dlls/user32/tests/monitor.c#L291). It makes sense to break windows compatibility here (especially with a bug!).