### PR TITLE
Fix typo in msi

### DIFF
--- a/dlls/msi/package.c
+++ b/dlls/msi/package.c
@@ -1742,7 +1742,7 @@ MSIHANDLE WINAPI MsiGetActiveDatabase(MSIHANDLE hInstall)
     {
         __TRY
         {
-            handle = remote_GetActiveDatabase(hInstall);
+            handle = remote_GetActiveDatabase(remote);
             handle = alloc_msi_remote_handle(handle);
         }
         __EXCEPT(rpc_filter)


### PR DESCRIPTION
This fixes a regression in wine that was [identified in the mailing list](https://www.winehq.org/pipermail/wine-cvs/2018-September/130002.html). It prevents the installation of dotnet40 in winetricks, and probably other software that uses msi to install.

The fix has already been committed to upstream wine.