### PR TITLE
add necessary lib flags for faudio with ffmpeg

### DIFF
--- a/configure
+++ b/configure
@@ -13895,7 +13895,7 @@ if ${FAUDIO_LIBS:+false} :; then :
 fi
 fi
 
-FAUDIO_LIBS=${FAUDIO_LIBS:-"-lFAudio"}
+FAUDIO_LIBS=${FAUDIO_LIBS:-"-lFAudio -lavcodec -lavutil -lswresample"}
 $as_echo "$as_me:${as_lineno-$LINENO}: faudio cflags: $FAUDIO_CFLAGS" >&5
 $as_echo "$as_me:${as_lineno-$LINENO}: faudio libs: $FAUDIO_LIBS" >&5
 ac_save_CPPFLAGS=$CPPFLAGS


### PR DESCRIPTION
These need to be added in order for faudio compiled with ffmpeg to work with wine. This is to be used with this PR: https://github.com/ValveSoftware/Proton/pull/2082