### PR TITLE
XACT3_VER typos, IXAudio23 compatibility fix

### DIFF
--- a/dlls/xaudio2_7/xact_dll.c
+++ b/dlls/xaudio2_7/xact_dll.c
@@ -23,7 +23,12 @@
 #define NONAMELESSUNION
 #define COBJMACROS
 
+/* We need to access some of the XAudio2 internals, for full compatibility with
+ * XACT's low-level APIs. The XAudio2 version should match the XACT3 version.
+ */
+#define XAUDIO2_VER XACT3_VER
 #include "xaudio_private.h"
+
 #include "initguid.h"
 #include "xact3.h"
 
@@ -34,21 +39,21 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(xact3);
 
-/* xaudio_allocator.c */
-extern void* XAudio_Internal_Malloc(size_t size) DECLSPEC_HIDDEN;
-extern void XAudio_Internal_Free(void* ptr) DECLSPEC_HIDDEN;
-extern void* XAudio_Internal_Realloc(void* ptr, size_t size) DECLSPEC_HIDDEN;
-
 /* XACT3 versions should line up with XAudio2 versions */
-#if XACT_VERSION == 0
+#if XACT3_VER == 0
 static inline IXAudio2Impl *impl_from_IXAudio20(IXAudio20 *iface)
 {
     return CONTAINING_RECORD(iface, IXAudio2Impl, IXAudio20_iface);
 }
-#elif XACT_VERSION <= 2
+#elif XACT3_VER <= 2
 static inline IXAudio2Impl *impl_from_IXAudio22(IXAudio22 *iface)
 {
     return CONTAINING_RECORD(iface, IXAudio2Impl, IXAudio22_iface);
+}
+#elif XACT3_VER <= 3
+static inline IXAudio2Impl *impl_from_IXAudio23(IXAudio23 *iface)
+{
+    return CONTAINING_RECORD(iface, IXAudio2Impl, IXAudio23_iface);
 }
 #else
 static inline IXAudio2Impl *impl_from_IXAudio27(IXAudio27 *iface)
@@ -56,18 +61,18 @@ static inline IXAudio2Impl *impl_from_IXAudio27(IXAudio27 *iface)
     return CONTAINING_RECORD(iface, IXAudio2Impl, IXAudio27_iface);
 }
 #endif
-#if XACT_VERSION == 0
-XA2VoiceImpl *impl_from_IXAudio20MasteringVoice(IXAudio20MasteringVoice *iface)
+#if XACT3_VER == 0
+static inline XA2VoiceImpl *impl_from_IXAudio20MasteringVoice(IXAudio20MasteringVoice *iface)
 {
     return CONTAINING_RECORD(iface, XA2VoiceImpl, IXAudio20MasteringVoice_iface);
 }
-#elif XACT_VERSION <= 3
-XA2VoiceImpl *impl_from_IXAudio23MasteringVoice(IXAudio23MasteringVoice *iface)
+#elif XACT3_VER <= 3
+static inline XA2VoiceImpl *impl_from_IXAudio23MasteringVoice(IXAudio23MasteringVoice *iface)
 {
     return CONTAINING_RECORD(iface, XA2VoiceImpl, IXAudio23MasteringVoice_iface);
 }
 #else
-XA2VoiceImpl *impl_from_IXAudio27MasteringVoice(IXAudio27MasteringVoice *iface)
+static inline XA2VoiceImpl *impl_from_IXAudio27MasteringVoice(IXAudio27MasteringVoice *iface)
 {
     return CONTAINING_RECORD(iface, XA2VoiceImpl, IXAudio27MasteringVoice_iface);
 }
@@ -973,20 +978,22 @@ static HRESULT WINAPI IXACT3EngineImpl_Initialize(IXACT3Engine *iface,
     memcpy(&params, pParams, sizeof(FACTRuntimeParameters));
 
     if (pParams->pXAudio2 != NULL){
-#if XACT_VERSION == 0
+#if XACT3_VER == 0
         xaudio = impl_from_IXAudio20((IXAudio20*) pParams->pXAudio2);
-#elif XACT_VERSION <= 2
+#elif XACT3_VER <= 2
         xaudio = impl_from_IXAudio22((IXAudio22*) pParams->pXAudio2);
+#elif XACT3_VER <= 3
+        xaudio = impl_from_IXAudio23((IXAudio23*) pParams->pXAudio2);
 #else
         xaudio = impl_from_IXAudio27((IXAudio27*) pParams->pXAudio2);
 #endif
         params.pXAudio2 = xaudio->faudio;
 
         if (pParams->pMasteringVoice != NULL){
-#if XACT_VERSION == 0
+#if XACT3_VER == 0
             master = impl_from_IXAudio20MasteringVoice(
                     (IXAudio20MasteringVoice*) pParams->pMasteringVoice);
-#elif XACT_VERSION <= 3
+#elif XACT3_VER <= 3
             master = impl_from_IXAudio23MasteringVoice(
                     (IXAudio23MasteringVoice*) pParams->pMasteringVoice);
 #else


### PR DESCRIPTION
This fixes a pile of things mostly related to pre-XAudio2_7, most notably the horrible mistake I made of not using the correct version `#define` for any of the compatibility paths. As a bonus, I also update the patch to work with the new IXAudio23 interface that was added in Wine 4.3.