### PR TITLE
Use the dxredist X3DAudio/XAPOFX DLLs for 64-bit

### DIFF
--- a/dlls/xaudio2_7/x3daudio.c
+++ b/dlls/xaudio2_7/x3daudio.c
@@ -38,10 +38,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD reason, void *pReserved)
 
     switch (reason)
     {
-#ifndef _WIN64
     case DLL_WINE_PREATTACH:
         return FALSE;  /* prefer native version */
-#endif
     case DLL_PROCESS_ATTACH:
         DisableThreadLibraryCalls( hinstDLL );
         break;

--- a/dlls/xaudio2_7/xapofx.c
+++ b/dlls/xaudio2_7/xapofx.c
@@ -43,10 +43,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD reason, void *pReserved)
 
     switch (reason)
     {
-#ifndef _WIN64
     case DLL_WINE_PREATTACH:
         return FALSE;  /* prefer native version */
-#endif
     case DLL_PROCESS_ATTACH:
         DisableThreadLibraryCalls( hinstDLL );
         break;


### PR DESCRIPTION
This removes the `!_WIN64` guards for X3DAudio's and XAPOFX's `DLL_WINE_PREATTACH` cases for Proton.

The main reason we prefer the builtins for 64-bit is because XAudio2 has some strange behavior on Win64 for reasons unknown. However, that _only_ applies to XAudio2_*.dll; the other XAudio2 libraries should be perfectly safe to use. We still use FACT for XACT3 support since FACT works best with FAudio, but we can get some pretty good accuracy improvements from using Microsoft's X3DAudio (accuracy in F3DAudio still isn't great) and get all the proper effects from the official XAPOFX library (which we [don't have implemented at all right now](https://github.com/FNA-XNA/FAudio/issues/40)).