### PR TITLE
winex11: Fill WM_CLASS based on Steam appid

### DIFF
--- a/dlls/winex11.drv/window.c
+++ b/dlls/winex11.drv/window.c
@@ -870,10 +870,13 @@ static void set_initial_wm_hints( Display *display, Window window )
     /* class hints */
     if ((class_hints = XAllocClassHint()))
     {
-        static char wine[] = "Wine";
+        static char steam_proton[] = "steam_proton";
+        char proton_app_class[128];
+        char *app_id = getenv("SteamAppId");
 
+        snprintf(proton_app_class, sizeof(proton_app_class), "steam_app_%s", app_id);
         class_hints->res_name = process_name;
-        class_hints->res_class = wine;
+        class_hints->res_class = app_id ? proton_app_class : steam_proton;
         XSetClassHint( display, window, class_hints );
         XFree( class_hints );
     }


### PR DESCRIPTION
Some desktop environments (Gnome 3, Cinnamon) decide on an application
icon in the following order:

- If the first string in WM_CLASS property can be correlated to
  a name or StartupWMClass key in a .desktop entry file, then
  the associated icon will be used.
- If the second string in WM_CLASS property can be correlated to
  a name or StartupWMClass key in a .desktop entry file, then
  the associated icon will be used.
- If the application has indicated an icon resource through WM_HINTS
  property, then the associated X window or pixmaps will be used.

Upstream Wine usually deals with this by placing a .desktop file with
StartupWMClass filled to match first string in WM_CLASS property
(which is the name of exe file being run).

Wine in Proton does not do it, but still puts "Wine" as second string,
therefore desktop environment can't differentiate between Wine in
Proton and Wine installed in OS.

By replacing "Wine" with "steam_app_<appid>" we force DE to fallback
to icon indicated by WM_HINTS (ico file embedded in exe file).
Steam can override this behaviour by installing properly crafted
.desktop entry file.  If SteamAppId environment variable is missing,
then generic "steam_proton" name is used instead.