### PR TITLE
Update to FAudio 19.06

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1642,6 +1642,10 @@ then
     WINE_PACKAGE_FLAGS(FAUDIO,[faudio],[-lFAudio],,,
         [AC_CHECK_HEADERS([FAudio.h],
             [WINE_CHECK_SONAME(FAudio,FAudioCreate,,,[$FAUDIO_LIBS],[[libFAudio*]])])])
+    WINE_CHECK_LIB_FUNCS(\
+        FAudio_CommitOperationSet \
+        F3DAudioInitialize8,
+        [$FAUDIO_LIBS])
 fi
 WINE_NOTICE_WITH(faudio,[test "x$ac_cv_lib_soname_FAudio" = "x"],
                  [libFAudio ${notice_platform}development files not found, XAudio2 won't be supported.])

--- a/dlls/xaudio2_7/x3daudio.c
+++ b/dlls/xaudio2_7/x3daudio.c
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include "config.h"
+
 #include <stdarg.h>
 
 #include "windef.h"
@@ -53,8 +55,12 @@ HRESULT CDECL X3DAudioInitialize(UINT32 chanmask, float speedofsound,
         X3DAUDIO_HANDLE handle)
 {
     TRACE("0x%x, %f, %p\n", chanmask, speedofsound, handle);
+#ifdef HAVE_F3DAUDIOINITIALIZE8
+    return F3DAudioInitialize8(chanmask, speedofsound, handle);
+#else
     F3DAudioInitialize(chanmask, speedofsound, handle);
     return S_OK;
+#endif
 }
 #endif /* XAUDIO2_VER >= 8 */
 

--- a/dlls/xaudio2_7/xaudio_dll.c
+++ b/dlls/xaudio2_7/xaudio_dll.c
@@ -1796,9 +1796,13 @@ static HRESULT WINAPI IXAudio2Impl_CommitChanges(IXAudio2 *iface,
 {
     IXAudio2Impl *This = impl_from_IXAudio2(iface);
 
-    TRACE("(%p)->(0x%x): stub!\n", This, operationSet);
+    TRACE("(%p)->(0x%x)\n", This, operationSet);
 
+#ifdef HAVE_FAUDIO_COMMITOPERATIONSET
+    return FAudio_CommitOperationSet(This->faudio, operationSet);
+#else
     return FAudio_CommitChanges(This->faudio);
+#endif
 }
 
 static void WINAPI IXAudio2Impl_GetPerformanceData(IXAudio2 *iface,


### PR DESCRIPTION
This uses the new functions introduced by FAudio 19.06, F3DAudioInitialize8 and FAudio_CommitOperationSet. The former's pretty boring, it just produces a real return code if a game gives us bogus initialize data, but the latter is basically required if games are going to keep working with FAudio 19.06 onward.

Operation sets can be extremely sensitive and affect a large portion of the XAudio2 spec, so the now-implemented operations will never execute and cause a memory leak and missing audio cues if the old CommitChanges is used. Similarly, we cannot actually do anything in FAudio_CommitChanges since the function cannot make assumptions about which sets to execute, so the function has been left as a stub with a single error message telling developers to update to CommitOperationSet.

Games affected include Warframe, DOOM 3 BFG, RAGE, Wolfenstein TNO, Wolfenstein TOB, XACT titles not using FACT (?), and potentially other titles using XAudio2 directly (I don't think Wwise uses operation sets).