### PR TITLE
d3d9: Implement d3d9_device_CreateRenderTargetEx().

### DIFF
--- a/dlls/d3d9/device.c
+++ b/dlls/d3d9/device.c
@@ -4031,16 +4031,31 @@ static HRESULT WINAPI d3d9_device_CreateRenderTargetEx(IDirect3DDevice9Ex *iface
         UINT width, UINT height, D3DFORMAT format, D3DMULTISAMPLE_TYPE multisample_type, DWORD multisample_quality,
         BOOL lockable, IDirect3DSurface9 **surface, HANDLE *shared_handle, DWORD usage)
 {
-    FIXME("iface %p, width %u, height %u, format %#x, multisample_type %#x, multisample_quality %u, "
-            "lockable %#x, surface %p, shared_handle %p, usage %#x stub!\n",
+    struct d3d9_device *device = impl_from_IDirect3DDevice9Ex(iface);
+    unsigned int access = WINED3D_RESOURCE_ACCESS_GPU;
+
+    TRACE("iface %p, width %u, height %u, format %#x, multisample_type %#x, multisample_quality %u, "
+            "lockable %#x, surface %p, shared_handle %p, usage %#x.\n",
             iface, width, height, format, multisample_type, multisample_quality,
             lockable, surface, shared_handle, usage);
 
     *surface = NULL;
+
+    if (usage & (D3DUSAGE_DEPTHSTENCIL | D3DUSAGE_RENDERTARGET))
+    {
+        WARN("Invalid usage %#x.\n", usage);
+        return D3DERR_INVALIDCALL;
+    }
+
     if (shared_handle)
         FIXME("Resource sharing not implemented, *shared_handle %p.\n", *shared_handle);
 
-    return E_NOTIMPL;
+    if (lockable)
+        access |= WINED3D_RESOURCE_ACCESS_MAP_R | WINED3D_RESOURCE_ACCESS_MAP_W;
+
+    return d3d9_device_create_surface(device, 0, wined3dformat_from_d3dformat(format),
+            multisample_type, multisample_quality, usage & WINED3DUSAGE_MASK,
+            WINED3D_BIND_RENDER_TARGET, access, width, height, NULL, surface);
 }
 
 static HRESULT WINAPI d3d9_device_CreateOffscreenPlainSurfaceEx(IDirect3DDevice9Ex *iface,

--- a/dlls/d3d9/tests/d3d9ex.c
+++ b/dlls/d3d9/tests/d3d9ex.c
@@ -3883,7 +3883,7 @@ static void test_format_unknown(void)
     iface = (void *)0xdeadbeef;
     hr = IDirect3DDevice9Ex_CreateRenderTargetEx(device, 64, 64,
             D3DFMT_UNKNOWN, D3DMULTISAMPLE_NONE, 0, FALSE, (IDirect3DSurface9 **)&iface, NULL, 0);
-    todo_wine ok(hr == D3DERR_INVALIDCALL, "Got unexpected hr %#x.\n", hr);
+    ok(hr == D3DERR_INVALIDCALL, "Got unexpected hr %#x.\n", hr);
     ok(!iface, "Got unexpected iface %p.\n", iface);
 
     iface = (void *)0xdeadbeef;
@@ -4323,8 +4323,7 @@ static void test_resource_access(void)
                 case SURFACE_RT_EX:
                     hr = IDirect3DDevice9Ex_CreateRenderTargetEx(device, 16, 16, format, D3DMULTISAMPLE_NONE,
                             0, tests[j].pool != D3DPOOL_DEFAULT, &surface, NULL, tests[j].usage);
-                    todo_wine
-                        ok(hr == (tests[j].format == FORMAT_COLOUR && !tests[j].usage ? D3D_OK : D3DERR_INVALIDCALL),
+                    ok(hr == (tests[j].format == FORMAT_COLOUR && !tests[j].usage ? D3D_OK : D3DERR_INVALIDCALL),
                                 "Test %s %u: Got unexpected hr %#x.\n", surface_types[i].name, j, hr);
                     if (FAILED(hr))
                         continue;


### PR DESCRIPTION
Signed-off-by: Justin Martin <jaming@protonmail.com>
Signed-off-by: Henri Verbeet <hverbeet@codeweavers.com>
Signed-off-by: Alexandre Julliard <julliard@winehq.org>

Cherry picked commit from [upstream 
](https://github.com/wine-mirror/wine/commit/6ad6c1ff4afe290482a5ac566e4d3f41f99b1e34) to fix [BBTAG](https://github.com/ValveSoftware/Proton/issues/2832).


