### PR TITLE
dinput: Fix DIPROP_GUIDANDPATH property in SDL backend

### DIFF
--- a/dlls/dinput/dinput_main.c
+++ b/dlls/dinput/dinput_main.c
@@ -47,6 +47,7 @@
 #include "objbase.h"
 #include "rpcproxy.h"
 #include "initguid.h"
+#include "devguid.h"
 #include "dinput_private.h"
 #include "device_private.h"
 #include "dinputd.h"

--- a/dlls/dinput/joystick_sdl.c
+++ b/dlls/dinput/joystick_sdl.c
@@ -45,6 +45,7 @@
 #include "winbase.h"
 #include "winerror.h"
 #include "winreg.h"
+#include "devguid.h"
 #include "dinput.h"
 
 #include "dinput_private.h"
@@ -656,19 +657,19 @@ static HRESULT WINAPI JoystickWImpl_GetProperty(LPDIRECTINPUTDEVICE8W iface, REF
 
         case (DWORD_PTR) DIPROP_GUIDANDPATH:
         {
-            static const WCHAR formatW[] =  {'\\','\\','?','\\','H','I','D','#','V','I','D','_','%','0','4', 'x','&',
-                                             'P','I','D','_','%','0','4','x','&', '%','s','_','%','i',0};
-            static const WCHAR imW[] = {'I','M',0};
-            static const WCHAR igW[] = {'I','G',0};
+            static const WCHAR formatW[] = {'\\','\\','?','\\','h','i','d','#','v','i','d','_','%','0','4','x','&',
+                                            'p','i','d','_','%','0','4','x','&','%','s','_','%','i',0};
+            static const WCHAR miW[] = {'m','i',0};
+            static const WCHAR igW[] = {'i','g',0};
 
             LPDIPROPGUIDANDPATH pd = (LPDIPROPGUIDANDPATH)pdiph;
 
             if (!This->sdldev->product_id || !This->sdldev->vendor_id)
                 return DIERR_UNSUPPORTED;
 
-            pd->guidClass = This->generic.base.guid;
+            pd->guidClass = GUID_DEVCLASS_HIDCLASS;
             sprintfW(pd->wszPath, formatW, This->sdldev->vendor_id, This->sdldev->product_id,
-                     This->sdldev->is_xbox_gamepad ? igW : imW, This->sdldev->id);
+                     This->sdldev->is_xbox_gamepad ? igW : miW, This->sdldev->id);
 
             TRACE("DIPROP_GUIDANDPATH(%s, %s): returning fake path\n", debugstr_guid(&pd->guidClass), debugstr_w(pd->wszPath));
             break;


### PR DESCRIPTION
The patch brings the current implementation of DIPROP_GUIDANDPATH property in line with the upstreamed patches for other backends.
@aeikum It may be worth it to squash the patch with the previous one.