### PR TITLE
Fix missing loader lock release in GetModuleHandleExW()

### DIFF
--- a/dlls/kernel32/module.c
+++ b/dlls/kernel32/module.c
@@ -479,6 +479,8 @@ BOOL WINAPI GetModuleHandleExW( DWORD flags, LPCWSTR name, HMODULE *module )
         UNICODE_STRING wstr;
         if(steamclient_hmod != NULL && strcasestrW(name, steamclientW)){
             *module = steamclient_hmod;
+            if (lock)
+                LdrUnlockLoaderLock( 0, magic );
             return TRUE;
         }
         RtlInitUnicodeString( &wstr, name );


### PR DESCRIPTION
[The return statement on line 482 in `dlls/kernel32/module.c`](https://github.com/ValveSoftware/wine/blob/aebdb22bb57128a5f38cd07d3952f1eb62e44817/dlls/kernel32/module.c#L482) may be executed without the loader lock set earlier never being released.