### PR TITLE
advapi32: Add EventWriteString stub.

### DIFF
--- a/dlls/advapi32/advapi32.spec
+++ b/dlls/advapi32/advapi32.spec
@@ -297,7 +297,7 @@
 # @ stub EventWriteEndScenario
 # @ stub EventWriteEx
 # @ stub EventWriteStartScenario
-# @ stub EventWriteString
+@ stdcall EventWriteString(int64 long int64 ptr)
 @ stdcall EventWriteTransfer(int64 ptr ptr ptr long ptr)
 @ stdcall FileEncryptionStatusA(str ptr)
 @ stdcall FileEncryptionStatusW(wstr ptr)

--- a/dlls/advapi32/eventlog.c
+++ b/dlls/advapi32/eventlog.c
@@ -837,6 +837,16 @@ ULONG WINAPI EventActivityIdControl(ULONG code, GUID *guid)
 }
 
 /******************************************************************************
+ * EventWriteString [ADVAPI32.@]
+ */
+ULONG WINAPI EventWriteString( REGHANDLE handle, UCHAR level, ULONGLONG keyword, PCWSTR string )
+{
+    FIXME("%s, %u, %s, %s: stub\n", wine_dbgstr_longlong(handle), level,
+          wine_dbgstr_longlong(keyword), debugstr_w(string));
+    return ERROR_SUCCESS;
+}
+
+/******************************************************************************
  * EventWriteTransfer [ADVAPI32.@]
  */
 ULONG WINAPI EventWriteTransfer( REGHANDLE handle, PCEVENT_DESCRIPTOR descriptor, LPCGUID activity,

--- a/dlls/api-ms-win-downlevel-advapi32-l1-1-0/api-ms-win-downlevel-advapi32-l1-1-0.spec
+++ b/dlls/api-ms-win-downlevel-advapi32-l1-1-0/api-ms-win-downlevel-advapi32-l1-1-0.spec
@@ -44,7 +44,7 @@
 @ stdcall EventRegister(ptr ptr ptr ptr) advapi32.EventRegister
 @ stdcall EventUnregister(int64) advapi32.EventUnregister
 @ stdcall EventWrite(int64 ptr long ptr) advapi32.EventWrite
-@ stub EventWriteString
+@ stdcall EventWriteString(int64 long int64 ptr) advapi32.EventWriteString
 @ stdcall EventWriteTransfer(int64 ptr ptr ptr long ptr) advapi32.EventWriteTransfer
 @ stdcall FindFirstFreeAce(ptr ptr) advapi32.FindFirstFreeAce
 @ stdcall FreeSid(ptr) advapi32.FreeSid

--- a/dlls/api-ms-win-eventing-provider-l1-1-0/api-ms-win-eventing-provider-l1-1-0.spec
+++ b/dlls/api-ms-win-eventing-provider-l1-1-0/api-ms-win-eventing-provider-l1-1-0.spec
@@ -6,5 +6,5 @@
 @ stdcall EventUnregister(int64) advapi32.EventUnregister
 @ stdcall EventWrite(int64 ptr long ptr) advapi32.EventWrite
 @ stub EventWriteEx
-@ stub EventWriteString
+@ stdcall EventWriteString(int64 long int64 ptr) advapi32.EventWriteString
 @ stdcall EventWriteTransfer(int64 ptr ptr ptr long ptr) advapi32.EventWriteTransfer

--- a/dlls/kernelbase/kernelbase.spec
+++ b/dlls/kernelbase/kernelbase.spec
@@ -335,7 +335,7 @@
 @ stdcall EventUnregister(int64) advapi32.EventUnregister
 @ stdcall EventWrite(int64 ptr long ptr) advapi32.EventWrite
 # @ stub EventWriteEx
-# @ stub EventWriteString
+@ stdcall EventWriteString(int64 long int64 ptr) advapi32.EventWriteString
 @ stdcall EventWriteTransfer(int64 ptr ptr ptr long ptr) advapi32.EventWriteTransfer
 @ stdcall ExitProcess(long) kernel32.ExitProcess
 @ stdcall ExitThread(long) kernel32.ExitThread


### PR DESCRIPTION
This fixes ValveSoftware/Proton#2616.