### PR TITLE
dinput: Remove is_xbox_gamepad flag from SDL joysticks

### DIFF
--- a/dlls/dinput/joystick_sdl.c
+++ b/dlls/dinput/joystick_sdl.c
@@ -87,7 +87,6 @@ struct SDLDev {
     WORD vendor_id;
     WORD product_id;
     CHAR *name;
-    BOOL is_xbox_gamepad;
 
     int n_buttons, n_axes, n_hats;
 
@@ -206,8 +205,6 @@ static void find_sdldevs(void)
                 type == SDL_JOYSTICK_TYPE_WHEEL ||
                 type == SDL_JOYSTICK_TYPE_FLIGHT_STICK ||
                 type == SDL_JOYSTICK_TYPE_THROTTLE;
-
-            sdldev.is_xbox_gamepad = is_xinput_device(NULL, sdldev.vendor_id, sdldev.product_id);
         }
 
         sdldev.n_buttons = SDL_JoystickNumButtons(device);
@@ -1011,14 +1008,16 @@ static HRESULT WINAPI JoystickWImpl_GetProperty(LPDIRECTINPUTDEVICE8W iface, REF
             static const WCHAR miW[] = {'m','i',0};
             static const WCHAR igW[] = {'i','g',0};
 
+            BOOL is_gamepad;
             LPDIPROPGUIDANDPATH pd = (LPDIPROPGUIDANDPATH)pdiph;
 
             if (!This->sdldev->product_id || !This->sdldev->vendor_id)
                 return DIERR_UNSUPPORTED;
 
+            is_gamepad = is_xinput_device(&This->generic.devcaps, This->sdldev->vendor_id, This->sdldev->product_id);
             pd->guidClass = GUID_DEVCLASS_HIDCLASS;
             sprintfW(pd->wszPath, formatW, This->sdldev->vendor_id, This->sdldev->product_id,
-                     This->sdldev->is_xbox_gamepad ? igW : miW, This->sdldev->id);
+                     is_gamepad ? igW : miW, This->sdldev->id);
 
             TRACE("DIPROP_GUIDANDPATH(%s, %s): returning fake path\n", debugstr_guid(&pd->guidClass), debugstr_w(pd->wszPath));
             break;


### PR DESCRIPTION
Just a bit of cleanup