### PR TITLE
.update added get_FMA3_enable function

### DIFF
--- a/dlls/api-ms-win-crt-math-l1-1-0/api-ms-win-crt-math-l1-1-0.spec
+++ b/dlls/api-ms-win-crt-math-l1-1-0/api-ms-win-crt-math-l1-1-0.spec
@@ -81,7 +81,7 @@
 @ cdecl _fpclass(double) ucrtbase._fpclass
 @ stub _fpclassf
 @ cdecl -arch=i386 -ret64 _ftol() ucrtbase._ftol
-@ stub _get_FMA3_enable
+@ cdecl -arch=win64 _get_FMA3_enable() ucrtbase._get_FMA3_enable
 @ cdecl _hypot(double double) ucrtbase._hypot
 @ cdecl _hypotf(float float) ucrtbase._hypotf
 @ cdecl _isnan(double) ucrtbase._isnan

--- a/dlls/msvcr120/msvcr120.spec
+++ b/dlls/msvcr120/msvcr120.spec
@@ -1639,6 +1639,7 @@
 @ stdcall -arch=i386 _seh_longjmp_unwind4(ptr)
 @ stdcall -arch=i386 _seh_longjmp_unwind(ptr)
 @ cdecl -arch=i386 _set_SSE2_enable(long) MSVCRT__set_SSE2_enable
+@ cdecl -arch=win64 _get_FMA3_enable() MSVCRT__get_FMA3_enable
 @ cdecl -arch=win64 _set_FMA3_enable(long) MSVCRT__set_FMA3_enable
 @ cdecl _set_abort_behavior(long long) MSVCRT__set_abort_behavior
 @ cdecl _set_controlfp(long long)

--- a/dlls/msvcrt/math.c
+++ b/dlls/msvcrt/math.c
@@ -123,12 +123,7 @@ int CDECL MSVCRT__set_SSE2_enable(int flag)
  */
 int CDECL MSVCRT__get_FMA3_enable(void)
 {
-    #if !defined(__FMA__) && defined(__AVX2__)
-        #define __FMA__ 1
-    #endif
-    #if defined(__FMA__)
-        return 1;
-    #endif
+    FIXME("() stub\n");
     return 0;
 }
 

--- a/dlls/msvcrt/math.c
+++ b/dlls/msvcrt/math.c
@@ -119,6 +119,20 @@ int CDECL MSVCRT__set_SSE2_enable(int flag)
 
 #if defined(_WIN64) && _MSVCR_VER>=120
 /*********************************************************************
+ *      _get_FMA3_enable (MSVCR120.@)
+ */
+int CDECL MSVCRT__get_FMA3_enable(void)
+{
+    #if !defined(__FMA__) && defined(__AVX2__)
+        #define __FMA__ 1
+    #endif
+    #if defined(__FMA__)
+        return 1;
+    #endif
+    return 0;
+}
+
+/*********************************************************************
  *      _set_FMA3_enable (MSVCR120.@)
  */
 int CDECL MSVCRT__set_FMA3_enable(int flag)

--- a/dlls/ucrtbase/ucrtbase.spec
+++ b/dlls/ucrtbase/ucrtbase.spec
@@ -357,7 +357,7 @@
 @ cdecl _fwrite_nolock(ptr long long ptr) MSVCRT__fwrite_nolock
 @ cdecl _gcvt(double long str) MSVCRT__gcvt
 @ cdecl _gcvt_s(ptr long  double long) MSVCRT__gcvt_s
-@ stub _get_FMA3_enable
+@ cdecl -arch=win64 _get_FMA3_enable() MSVCRT__get_FMA3_enable
 @ cdecl _get_current_locale() MSVCRT__get_current_locale
 @ cdecl _get_daylight(ptr)
 @ cdecl _get_doserrno(ptr)


### PR DESCRIPTION
necessary for eFootball PES 2020 (appId=996470).
fixes the startup crash described here: https://github.com/ValveSoftware/Proton/issues/3227