### PR TITLE
Add WINEUSER environment variable

### DIFF
--- a/dlls/advapi32/advapi.c
+++ b/dlls/advapi32/advapi.c
@@ -84,7 +84,7 @@ GetUserNameA( LPSTR lpszName, LPDWORD lpSize )
 BOOL WINAPI
 GetUserNameW( LPWSTR lpszName, LPDWORD lpSize )
 {
-    const char *name = "steamuser"/*wine_get_user_name()*/;
+    const char *name = wine_get_user_name();
     DWORD i, len = MultiByteToWideChar( CP_UNIXCP, 0, name, -1, NULL, 0 );
     LPWSTR backslash;
 
@@ -235,7 +235,7 @@ BOOL WINAPI InitiateSystemShutdownExA( LPSTR lpMachineName, LPSTR lpMessage,
             debugstr_a(lpMessage), dwTimeout, bForceAppsClosed,
             bRebootAfterShutdown, dwReason);
      return TRUE;
-} 
+}
 
 /******************************************************************************
  * InitiateSystemShutdownExW [ADVAPI32.@]
@@ -250,7 +250,7 @@ BOOL WINAPI InitiateSystemShutdownExW( LPWSTR lpMachineName, LPWSTR lpMessage,
             debugstr_w(lpMessage), dwTimeout, bForceAppsClosed,
             bRebootAfterShutdown, dwReason);
      return TRUE;
-} 
+}
 
 BOOL WINAPI InitiateSystemShutdownA( LPSTR lpMachineName, LPSTR lpMessage, DWORD dwTimeout,
                                      BOOL bForceAppsClosed, BOOL bRebootAfterShutdown )

--- a/libs/wine/config.c
+++ b/libs/wine/config.c
@@ -263,14 +263,14 @@ static void init_paths(void)
     struct stat st;
 
     const char *home = getenv( "HOME" );
-    const char *user = NULL;
+    const char *user = getenv( "WINEUSER" ) || "steamuser";
     const char *prefix = getenv( "WINEPREFIX" );
     char uid_str[32];
     struct passwd *pwd = getpwuid( getuid() );
 
     if (pwd)
     {
-        user = pwd->pw_name;
+        if (!user) user = pwd->pw_name;
         if (!home) home = pwd->pw_dir;
     }
     if (!user)


### PR DESCRIPTION
This is a modified mirror of [my patch to wine](https://source.winehq.org/patches/data/178254). This allows proton to be used on existing prefixes while sharing data from the home directory, without needing symlinks or copies (by using the `WINEUSER=...` environment variable).

On a sidenote, `GetUserNameExW` from secur32 and `GetNamedPipeHandleStateW` from kernel32 also call `wine_get_user_name`, which would return the real username instead of steamuser, so this patch fixes that as well :)

(Note: I haven't actually tested this specific patch, but I have tested the one I sent to wine)