### PR TITLE
winex11.drv: Support child window rendering for Vulkan via XComposite

### DIFF
--- a/dlls/winex11.drv/vulkan.c
+++ b/dlls/winex11.drv/vulkan.c
@@ -33,6 +33,7 @@
 #include "wine/heap.h"
 #include "wine/library.h"
 #include "x11drv.h"
+#include "xcomposite.h"
 
 #define VK_NO_PROTOTYPES
 #define WINE_VK_HOST
@@ -55,6 +56,7 @@ static CRITICAL_SECTION_DEBUG critsect_debug =
 static CRITICAL_SECTION context_section = { &critsect_debug, -1, 0, 0, 0, 0 };
 
 static XContext vulkan_hwnd_context;
+static XContext vulkan_swapchain_surface_context;
 
 static struct vulkan_funcs vulkan_funcs;
 
@@ -64,6 +66,7 @@ struct wine_vk_surface
 {
     LONG ref;
     Window window;
+    HDC child_window_dc;
     VkSurfaceKHR surface; /* native surface */
 };
 
@@ -148,6 +151,7 @@ static BOOL WINAPI wine_vk_init(INIT_ONCE *once, void *param, void **context)
 #undef LOAD_OPTIONAL_FUNCPTR
 
     vulkan_hwnd_context = XUniqueContext();
+    vulkan_swapchain_surface_context = XUniqueContext();
 
     return TRUE;
 
@@ -265,16 +269,24 @@ static VkResult X11DRV_vkCreateSwapchainKHR(VkDevice device,
         const VkSwapchainCreateInfoKHR *create_info,
         const VkAllocationCallbacks *allocator, VkSwapchainKHR *swapchain)
 {
+    VkResult res;
     VkSwapchainCreateInfoKHR create_info_host;
+    struct wine_vk_surface *x11_surface = surface_from_handle(create_info->surface);
+
     TRACE("%p %p %p %p\n", device, create_info, allocator, swapchain);
 
     if (allocator)
         FIXME("Support for allocation callbacks not implemented yet\n");
 
     create_info_host = *create_info;
-    create_info_host.surface = surface_from_handle(create_info->surface)->surface;
+    create_info_host.surface = x11_surface->surface;
 
-    return pvkCreateSwapchainKHR(device, &create_info_host, NULL /* allocator */, swapchain);
+    res = pvkCreateSwapchainKHR(device, &create_info_host, NULL /* allocator */, swapchain);
+    if (res == VK_SUCCESS)
+    {
+        XSaveContext(gdi_display, (XID)(*swapchain), vulkan_swapchain_surface_context, (char *)x11_surface);
+    }
+    return res;
 }
 
 static VkResult X11DRV_vkCreateWin32SurfaceKHR(VkInstance instance,
@@ -290,13 +302,6 @@ static VkResult X11DRV_vkCreateWin32SurfaceKHR(VkInstance instance,
     if (allocator)
         FIXME("Support for allocation callbacks not implemented yet\n");
 
-    /* TODO: support child window rendering. */
-    if (GetAncestor(create_info->hwnd, GA_PARENT) != GetDesktopWindow())
-    {
-        FIXME("Application requires child window rendering, which is not implemented yet!\n");
-        return VK_ERROR_INCOMPATIBLE_DRIVER;
-    }
-
     x11_surface = heap_alloc_zero(sizeof(*x11_surface));
     if (!x11_surface)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -311,6 +316,27 @@ static VkResult X11DRV_vkCreateWin32SurfaceKHR(VkInstance instance,
         /* VK_KHR_win32_surface only allows out of host and device memory as errors. */
         res = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto err;
+    }
+
+    /* child window rendering. */
+    if (GetAncestor(create_info->hwnd, GA_PARENT) != GetDesktopWindow())
+    {
+#ifdef SONAME_LIBXCOMPOSITE
+        if (usexcomposite)
+        {
+            pXCompositeRedirectWindow(gdi_display, x11_surface->window, CompositeRedirectManual);
+            x11_surface->child_window_dc = GetDC(create_info->hwnd);
+        }
+#else
+        if (0)
+        {
+        }
+#endif
+        else
+        {
+            FIXME("Child window rendering is not supported without X Composite Extension!\n");
+            return VK_ERROR_INCOMPATIBLE_DRIVER;
+        }
     }
 
     create_info_host.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
@@ -382,6 +408,7 @@ static void X11DRV_vkDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapcha
         FIXME("Support for allocation callbacks not implemented yet\n");
 
     pvkDestroySwapchainKHR(device, swapchain, NULL /* allocator */);
+    XDeleteContext(gdi_display, (XID)swapchain, vulkan_swapchain_surface_context);
 }
 
 static VkResult X11DRV_vkEnumerateInstanceExtensionProperties(const char *layer_name,
@@ -579,6 +606,21 @@ static VkResult X11DRV_vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *
             frames = 0;
             if (!start_time)
                 start_time = time;
+        }
+    }
+
+    for (uint32_t i = 0 ; i < present_info->swapchainCount; ++i)
+    {
+        struct wine_vk_surface *x11_surface;
+        if (!XFindContext(gdi_display, (XID)present_info->pSwapchains[i],
+                          vulkan_swapchain_surface_context, (char **)&x11_surface) &&
+            x11_surface->child_window_dc)
+        {
+            struct x11drv_escape_flush_gl_drawable escape;
+            escape.code = X11DRV_FLUSH_GL_DRAWABLE;
+            escape.gl_drawable = x11_surface->window;
+            escape.flush = TRUE;
+            ExtEscape(x11_surface->child_window_dc, X11DRV_ESCAPE, sizeof(escape), (LPSTR)&escape, 0, NULL);
         }
     }
 


### PR DESCRIPTION
In relation to https://github.com/ValveSoftware/Proton/pull/3886 and https://github.com/ValveSoftware/Proton/issues/3681 the Workshop Tools have child windows (the preview panes, Hammer views, etc.) that do not display: `006b:fixme:vulkan: X11DRV_vkCreateWin32SurfaceKHR Application requires child window rendering , which is not implemented yet!`

Upstream issue: https://bugs.winehq.org/show_bug.cgi?id=45277