### PR TITLE
dxdiagn improvements for Rainbow Six: Lockdown

### DIFF
--- a/dlls/dxdiagn/Makefile.in
+++ b/dlls/dxdiagn/Makefile.in
@@ -1,5 +1,5 @@
 MODULE    = dxdiagn.dll
-IMPORTS   = strmiids dxguid uuid d3d9 ddraw version ole32 oleaut32 user32 advapi32
+IMPORTS   = strmiids dxguid uuid d3d9 ddraw dsound version ole32 oleaut32 user32 advapi32
 
 EXTRADLLFLAGS = -mno-cygwin
 

--- a/dlls/dxdiagn/container.c
+++ b/dlls/dxdiagn/container.c
@@ -160,6 +160,14 @@ static HRESULT WINAPI IDxDiagContainerImpl_GetChildContainer(IDxDiagContainer *i
   if (NULL == tmp) return E_FAIL;
   lstrcpynW(tmp, pwszContainer, tmp_len);
 
+  /* special handling for an empty string and leaf container */
+  if (!tmp[0] && list_empty(&pContainer->subContainers)) {
+    hr = DXDiag_CreateDXDiagContainer(&IID_IDxDiagContainer, pContainer, This->pProv, (void **)ppInstance);
+    if (SUCCEEDED(hr))
+      TRACE("Succeeded in getting the container instance\n");
+    goto out;
+  }
+
   cur = wcschr(tmp, '.');
   while (NULL != cur) {
     *cur = '\0'; /* cut tmp string to '.' */
@@ -167,7 +175,7 @@ static HRESULT WINAPI IDxDiagContainerImpl_GetChildContainer(IDxDiagContainer *i
     TRACE("Trying to get parent container %s\n", debugstr_w(tmp));
     hr = IDxDiagContainerImpl_GetChildContainerInternal(pContainer, tmp, &pContainer);
     if (FAILED(hr))
-      goto on_error;
+      goto out;
     cur++; /* go after '.' (just replaced by \0) */
     tmp = cur;
     cur = wcschr(tmp, '.');
@@ -181,7 +189,7 @@ static HRESULT WINAPI IDxDiagContainerImpl_GetChildContainer(IDxDiagContainer *i
         TRACE("Succeeded in getting the container instance\n");
   }
 
-on_error:
+out:
   HeapFree(GetProcessHeap(), 0, orig_tmp);
   return hr;
 }

--- a/dlls/dxdiagn/tests/container.c
+++ b/dlls/dxdiagn/tests/container.c
@@ -34,9 +34,6 @@ struct property_test
 static IDxDiagProvider *pddp;
 static IDxDiagContainer *pddc;
 
-static const WCHAR DxDiag_SystemInfo[] = {'D','x','D','i','a','g','_','S','y','s','t','e','m','I','n','f','o',0};
-static const WCHAR DxDiag_DisplayDevices[] = {'D','x','D','i','a','g','_','D','i','s','p','l','a','y','D','e','v','i','c','e','s',0};
-
 static BOOL create_root_IDxDiagContainer(void)
 {
     HRESULT hr;
@@ -115,8 +112,7 @@ static void test_EnumChildContainerNames(void)
     HRESULT hr;
     WCHAR container[256];
     DWORD maxcount, index;
-    static const WCHAR testW[] = {'t','e','s','t',0};
-    static const WCHAR zerotestW[] = {0,'e','s','t',0};
+    static const WCHAR testW[] = L"test";
 
     if (!create_root_IDxDiagContainer())
     {
@@ -152,7 +148,7 @@ static void test_EnumChildContainerNames(void)
     hr = IDxDiagContainer_EnumChildContainerNames(pddc, ~0, container, ARRAY_SIZE(container));
     ok(hr == E_INVALIDARG,
        "Expected IDxDiagContainer::EnumChildContainerNames to return E_INVALIDARG, got 0x%08x\n", hr);
-    ok(!memcmp(container, zerotestW, sizeof(zerotestW)),
+    ok(!memcmp(container, L"\0est", sizeof(L"\0est")),
        "Expected the container buffer string to be empty, got %s\n", wine_dbgstr_w(container));
 
     hr = IDxDiagContainer_GetNumberOfChildContainers(pddc, &maxcount);
@@ -403,7 +399,7 @@ static void test_EnumPropNames(void)
     WCHAR container[256], property[256];
     IDxDiagContainer *child = NULL;
     DWORD count, index, propcount;
-    static const WCHAR testW[] = {'t','e','s','t',0};
+    static const WCHAR testW[] = L"test";
 
     if (!create_root_IDxDiagContainer())
     {
@@ -547,8 +543,7 @@ static void test_GetProp(void)
     SAFEARRAY *sa;
     SAFEARRAYBOUND bound;
     ULONG ref;
-    static const WCHAR emptyW[] = {0};
-    static const WCHAR testW[] = {'t','e','s','t',0};
+    static const WCHAR testW[] = L"test";
 
     if (!create_root_IDxDiagContainer())
     {
@@ -608,11 +603,11 @@ static void test_GetProp(void)
     ok(hr == E_INVALIDARG, "Expected IDxDiagContainer::GetProp to return E_INVALIDARG, got 0x%08x\n", hr);
     ok(V_VT(&var) == 0xdead, "Expected the variant to be untouched, got %u\n", V_VT(&var));
 
-    hr = IDxDiagContainer_GetProp(child, emptyW, NULL);
+    hr = IDxDiagContainer_GetProp(child, L"", NULL);
     ok(hr == E_INVALIDARG, "Expected IDxDiagContainer::GetProp to return E_INVALIDARG, got 0x%08x\n", hr);
 
     V_VT(&var) = 0xdead;
-    hr = IDxDiagContainer_GetProp(child, emptyW, &var);
+    hr = IDxDiagContainer_GetProp(child, L"", &var);
     ok(hr == E_INVALIDARG, "Expected IDxDiagContainer::GetProp to return E_INVALIDARG, got 0x%08x\n", hr);
     ok(V_VT(&var) == 0xdead, "Expected the variant to be untouched, got %u\n", V_VT(&var));
 
@@ -682,23 +677,14 @@ cleanup:
 
 static void test_root_children(void)
 {
-    static const WCHAR DxDiag_DirectSound[] = {'D','x','D','i','a','g','_','D','i','r','e','c','t','S','o','u','n','d',0};
-    static const WCHAR DxDiag_DirectMusic[] = {'D','x','D','i','a','g','_','D','i','r','e','c','t','M','u','s','i','c',0};
-    static const WCHAR DxDiag_DirectInput[] = {'D','x','D','i','a','g','_','D','i','r','e','c','t','I','n','p','u','t',0};
-    static const WCHAR DxDiag_DirectPlay[] = {'D','x','D','i','a','g','_','D','i','r','e','c','t','P','l','a','y',0};
-    static const WCHAR DxDiag_SystemDevices[] = {'D','x','D','i','a','g','_','S','y','s','t','e','m','D','e','v','i','c','e','s',0};
-    static const WCHAR DxDiag_DirectXFiles[] = {'D','x','D','i','a','g','_','D','i','r','e','c','t','X','F','i','l','e','s',0};
-    static const WCHAR DxDiag_DirectShowFilters[] = {'D','x','D','i','a','g','_','D','i','r','e','c','t','S','h','o','w','F','i','l','t','e','r','s',0};
-    static const WCHAR DxDiag_LogicalDisks[] = {'D','x','D','i','a','g','_','L','o','g','i','c','a','l','D','i','s','k','s',0};
-
     HRESULT hr;
     DWORD count, index;
 
     static const WCHAR *root_children[] = {
-        DxDiag_SystemInfo, DxDiag_DisplayDevices, DxDiag_DirectSound,
-        DxDiag_DirectMusic, DxDiag_DirectInput, DxDiag_DirectPlay,
-        DxDiag_SystemDevices, DxDiag_DirectXFiles, DxDiag_DirectShowFilters,
-        DxDiag_LogicalDisks
+        L"DxDiag_SystemInfo", L"DxDiag_DisplayDevices", L"DxDiag_DirectSound",
+        L"DxDiag_DirectMusic", L"DxDiag_DirectInput", L"DxDiag_DirectPlay",
+        L"DxDiag_SystemDevices", L"DxDiag_DirectXFiles", L"DxDiag_DirectShowFilters",
+        L"DxDiag_LogicalDisks"
     };
 
     if (!create_root_IDxDiagContainer())
@@ -796,75 +782,41 @@ static void test_container_properties(IDxDiagContainer *container, const struct 
 
 static void test_DxDiag_SystemInfo(void)
 {
-    static const WCHAR dwOSMajorVersion[] = {'d','w','O','S','M','a','j','o','r','V','e','r','s','i','o','n',0};
-    static const WCHAR dwOSMinorVersion[] = {'d','w','O','S','M','i','n','o','r','V','e','r','s','i','o','n',0};
-    static const WCHAR dwOSBuildNumber[] = {'d','w','O','S','B','u','i','l','d','N','u','m','b','e','r',0};
-    static const WCHAR dwOSPlatformID[] = {'d','w','O','S','P','l','a','t','f','o','r','m','I','D',0};
-    static const WCHAR dwDirectXVersionMajor[] = {'d','w','D','i','r','e','c','t','X','V','e','r','s','i','o','n','M','a','j','o','r',0};
-    static const WCHAR dwDirectXVersionMinor[] = {'d','w','D','i','r','e','c','t','X','V','e','r','s','i','o','n','M','i','n','o','r',0};
-    static const WCHAR szDirectXVersionLetter[] = {'s','z','D','i','r','e','c','t','X','V','e','r','s','i','o','n','L','e','t','t','e','r',0};
-    static const WCHAR bDebug[] = {'b','D','e','b','u','g',0};
-    static const WCHAR bNECPC98[] = {'b','N','E','C','P','C','9','8',0};
-    static const WCHAR ullPhysicalMemory[] = {'u','l','l','P','h','y','s','i','c','a','l','M','e','m','o','r','y',0};
-    static const WCHAR ullUsedPageFile[] = {'u','l','l','U','s','e','d','P','a','g','e','F','i','l','e',0};
-    static const WCHAR ullAvailPageFile[] = {'u','l','l','A','v','a','i','l','P','a','g','e','F','i','l','e',0};
-    static const WCHAR szWindowsDir[] = {'s','z','W','i','n','d','o','w','s','D','i','r',0};
-    static const WCHAR szCSDVersion[] = {'s','z','C','S','D','V','e','r','s','i','o','n',0};
-    static const WCHAR szDirectXVersionEnglish[] = {'s','z','D','i','r','e','c','t','X','V','e','r','s','i','o','n','E','n','g','l','i','s','h',0};
-    static const WCHAR szDirectXVersionLongEnglish[] = {'s','z','D','i','r','e','c','t','X','V','e','r','s','i','o','n','L','o','n','g','E','n','g','l','i','s','h',0};
-    static const WCHAR bNetMeetingRunning[] = {'b','N','e','t','M','e','e','t','i','n','g','R','u','n','n','i','n','g',0};
-    static const WCHAR szMachineNameLocalized[] = {'s','z','M','a','c','h','i','n','e','N','a','m','e','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szMachineNameEnglish[] = {'s','z','M','a','c','h','i','n','e','N','a','m','e','E','n','g','l','i','s','h',0};
-    static const WCHAR szLanguagesLocalized[] = {'s','z','L','a','n','g','u','a','g','e','s','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szLanguagesEnglish[] = {'s','z','L','a','n','g','u','a','g','e','s','E','n','g','l','i','s','h',0};
-    static const WCHAR szTimeLocalized[] = {'s','z','T','i','m','e','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szTimeEnglish[] = {'s','z','T','i','m','e','E','n','g','l','i','s','h',0};
-    static const WCHAR szPhysicalMemoryEnglish[] = {'s','z','P','h','y','s','i','c','a','l','M','e','m','o','r','y','E','n','g','l','i','s','h',0};
-    static const WCHAR szPageFileLocalized[] = {'s','z','P','a','g','e','F','i','l','e','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szPageFileEnglish[] = {'s','z','P','a','g','e','F','i','l','e','E','n','g','l','i','s','h',0};
-    static const WCHAR szOSLocalized[] = {'s','z','O','S','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szOSExLocalized[] = {'s','z','O','S','E','x','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szOSExLongLocalized[] = {'s','z','O','S','E','x','L','o','n','g','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szOSEnglish[] = {'s','z','O','S','E','n','g','l','i','s','h',0};
-    static const WCHAR szOSExEnglish[] = {'s','z','O','S','E','x','E','n','g','l','i','s','h',0};
-    static const WCHAR szOSExLongEnglish[] = {'s','z','O','S','E','x','L','o','n','g','E','n','g','l','i','s','h',0};
-    static const WCHAR szProcessorEnglish[] = {'s','z','P','r','o','c','e','s','s','o','r','E','n','g','l','i','s','h',0};
-
     static const struct property_test property_tests[] =
     {
-        {dwOSMajorVersion, VT_UI4},
-        {dwOSMinorVersion, VT_UI4},
-        {dwOSBuildNumber, VT_UI4},
-        {dwOSPlatformID, VT_UI4},
-        {dwDirectXVersionMajor, VT_UI4},
-        {dwDirectXVersionMinor, VT_UI4},
-        {szDirectXVersionLetter, VT_BSTR},
-        {bDebug, VT_BOOL},
-        {bNECPC98, VT_BOOL},
-        {ullPhysicalMemory, VT_BSTR},
-        {ullUsedPageFile, VT_BSTR},
-        {ullAvailPageFile, VT_BSTR},
-        {szWindowsDir, VT_BSTR},
-        {szCSDVersion, VT_BSTR},
-        {szDirectXVersionEnglish, VT_BSTR},
-        {szDirectXVersionLongEnglish, VT_BSTR},
-        {bNetMeetingRunning, VT_BOOL},
-        {szMachineNameLocalized, VT_BSTR},
-        {szMachineNameEnglish, VT_BSTR},
-        {szLanguagesLocalized, VT_BSTR},
-        {szLanguagesEnglish, VT_BSTR},
-        {szTimeLocalized, VT_BSTR},
-        {szTimeEnglish, VT_BSTR},
-        {szPhysicalMemoryEnglish, VT_BSTR},
-        {szPageFileLocalized, VT_BSTR},
-        {szPageFileEnglish, VT_BSTR},
-        {szOSLocalized, VT_BSTR},
-        {szOSExLocalized, VT_BSTR},
-        {szOSExLongLocalized, VT_BSTR},
-        {szOSEnglish, VT_BSTR},
-        {szOSExEnglish, VT_BSTR},
-        {szOSExLongEnglish, VT_BSTR},
-        {szProcessorEnglish, VT_BSTR},
+        {L"dwOSMajorVersion", VT_UI4},
+        {L"dwOSMinorVersion", VT_UI4},
+        {L"dwOSBuildNumber", VT_UI4},
+        {L"dwOSPlatformID", VT_UI4},
+        {L"dwDirectXVersionMajor", VT_UI4},
+        {L"dwDirectXVersionMinor", VT_UI4},
+        {L"szDirectXVersionLetter", VT_BSTR},
+        {L"bDebug", VT_BOOL},
+        {L"bNECPC98", VT_BOOL},
+        {L"ullPhysicalMemory", VT_BSTR},
+        {L"ullUsedPageFile", VT_BSTR},
+        {L"ullAvailPageFile", VT_BSTR},
+        {L"szWindowsDir", VT_BSTR},
+        {L"szCSDVersion", VT_BSTR},
+        {L"szDirectXVersionEnglish", VT_BSTR},
+        {L"szDirectXVersionLongEnglish", VT_BSTR},
+        {L"bNetMeetingRunning", VT_BOOL},
+        {L"szMachineNameLocalized", VT_BSTR},
+        {L"szMachineNameEnglish", VT_BSTR},
+        {L"szLanguagesLocalized", VT_BSTR},
+        {L"szLanguagesEnglish", VT_BSTR},
+        {L"szTimeLocalized", VT_BSTR},
+        {L"szTimeEnglish", VT_BSTR},
+        {L"szPhysicalMemoryEnglish", VT_BSTR},
+        {L"szPageFileLocalized", VT_BSTR},
+        {L"szPageFileEnglish", VT_BSTR},
+        {L"szOSLocalized", VT_BSTR},
+        {L"szOSExLocalized", VT_BSTR},
+        {L"szOSExLongLocalized", VT_BSTR},
+        {L"szOSEnglish", VT_BSTR},
+        {L"szOSExEnglish", VT_BSTR},
+        {L"szOSExLongEnglish", VT_BSTR},
+        {L"szProcessorEnglish", VT_BSTR},
     };
 
     IDxDiagContainer *container;
@@ -876,7 +828,7 @@ static void test_DxDiag_SystemInfo(void)
         return;
     }
 
-    hr = IDxDiagContainer_GetChildContainer(pddc, DxDiag_SystemInfo, &container);
+    hr = IDxDiagContainer_GetChildContainer(pddc, L"DxDiag_SystemInfo", &container);
     ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
 
     if (hr == S_OK)
@@ -892,53 +844,30 @@ static void test_DxDiag_SystemInfo(void)
 
 static void test_DxDiag_DisplayDevices(void)
 {
-    static const WCHAR szDescription[] = {'s','z','D','e','s','c','r','i','p','t','i','o','n',0};
-    static const WCHAR szDeviceName[] = {'s','z','D','e','v','i','c','e','N','a','m','e',0};
-    static const WCHAR szKeyDeviceID[] = {'s','z','K','e','y','D','e','v','i','c','e','I','D',0};
-    static const WCHAR szKeyDeviceKey[] = {'s','z','K','e','y','D','e','v','i','c','e','K','e','y',0};
-    static const WCHAR szVendorId[] = {'s','z','V','e','n','d','o','r','I','d',0};
-    static const WCHAR szDeviceId[] = {'s','z','D','e','v','i','c','e','I','d',0};
-    static const WCHAR szDeviceIdentifier[] = {'s','z','D','e','v','i','c','e','I','d','e','n','t','i','f','i','e','r',0};
-    static const WCHAR dwWidth[] = {'d','w','W','i','d','t','h',0};
-    static const WCHAR dwHeight[] = {'d','w','H','e','i','g','h','t',0};
-    static const WCHAR dwBpp[] = {'d','w','B','p','p',0};
-    static const WCHAR szDisplayMemoryLocalized[] = {'s','z','D','i','s','p','l','a','y','M','e','m','o','r','y','L','o','c','a','l','i','z','e','d',0};
-    static const WCHAR szDisplayMemoryEnglish[] = {'s','z','D','i','s','p','l','a','y','M','e','m','o','r','y','E','n','g','l','i','s','h',0};
-    static const WCHAR szDriverName[] = {'s','z','D','r','i','v','e','r','N','a','m','e',0};
-    static const WCHAR szDriverVersion[] = {'s','z','D','r','i','v','e','r','V','e','r','s','i','o','n',0};
-    static const WCHAR szSubSysId[] = {'s','z','S','u','b','S','y','s','I','d',0};
-    static const WCHAR szRevisionId[] = {'s','z','R','e','v','i','s','i','o','n','I','d',0};
-    static const WCHAR dwRefreshRate[] = {'d','w','R','e','f','r','e','s','h','R','a','t','e',0};
-    static const WCHAR szManufacturer[] = {'s','z','M','a','n','u','f','a','c','t','u','r','e','r',0};
-    static const WCHAR b3DAccelerationExists[] = {'b','3','D','A','c','c','e','l','e','r','a','t','i','o','n','E','x','i','s','t','s',0};
-    static const WCHAR b3DAccelerationEnabled[] = {'b','3','D','A','c','c','e','l','e','r','a','t','i','o','n','E','n','a','b','l','e','d',0};
-    static const WCHAR bDDAccelerationEnabled[] = {'b','D','D','A','c','c','e','l','e','r','a','t','i','o','n','E','n','a','b','l','e','d',0};
-    static const WCHAR iAdapter[] = {'i','A','d','a','p','t','e','r',0};
-
     static const struct property_test property_tests[] =
     {
-        {szDescription, VT_BSTR},
-        {szDeviceName, VT_BSTR},
-        {szKeyDeviceID, VT_BSTR},
-        {szKeyDeviceKey, VT_BSTR},
-        {szVendorId, VT_BSTR},
-        {szDeviceId, VT_BSTR},
-        {szDeviceIdentifier, VT_BSTR},
-        {dwWidth, VT_UI4},
-        {dwHeight, VT_UI4},
-        {dwBpp, VT_UI4},
-        {szDisplayMemoryLocalized, VT_BSTR},
-        {szDisplayMemoryEnglish, VT_BSTR},
-        {szDriverName, VT_BSTR},
-        {szDriverVersion, VT_BSTR},
-        {szSubSysId, VT_BSTR},
-        {szRevisionId, VT_BSTR},
-        {dwRefreshRate, VT_UI4},
-        {szManufacturer, VT_BSTR},
-        {b3DAccelerationExists, VT_BOOL},
-        {b3DAccelerationEnabled, VT_BOOL},
-        {bDDAccelerationEnabled, VT_BOOL},
-        {iAdapter, VT_UI4},
+        {L"szDescription", VT_BSTR},
+        {L"szDeviceName", VT_BSTR},
+        {L"szKeyDeviceID", VT_BSTR},
+        {L"szKeyDeviceKey", VT_BSTR},
+        {L"szVendorId", VT_BSTR},
+        {L"szDeviceId", VT_BSTR},
+        {L"szDeviceIdentifier", VT_BSTR},
+        {L"dwWidth", VT_UI4},
+        {L"dwHeight", VT_UI4},
+        {L"dwBpp", VT_UI4},
+        {L"szDisplayMemoryLocalized", VT_BSTR},
+        {L"szDisplayMemoryEnglish", VT_BSTR},
+        {L"szDriverName", VT_BSTR},
+        {L"szDriverVersion", VT_BSTR},
+        {L"szSubSysId", VT_BSTR},
+        {L"szRevisionId", VT_BSTR},
+        {L"dwRefreshRate", VT_UI4},
+        {L"szManufacturer", VT_BSTR},
+        {L"b3DAccelerationExists", VT_BOOL},
+        {L"b3DAccelerationEnabled", VT_BOOL},
+        {L"bDDAccelerationEnabled", VT_BOOL},
+        {L"iAdapter", VT_UI4},
     };
 
     IDxDiagContainer *display_cont = NULL;
@@ -951,7 +880,7 @@ static void test_DxDiag_DisplayDevices(void)
         return;
     }
 
-    hr = IDxDiagContainer_GetChildContainer(pddc, DxDiag_DisplayDevices, &display_cont);
+    hr = IDxDiagContainer_GetChildContainer(pddc, L"DxDiag_DisplayDevices", &display_cont);
     ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
 
     if (hr != S_OK)

--- a/dlls/dxdiagn/tests/container.c
+++ b/dlls/dxdiagn/tests/container.c
@@ -819,7 +819,7 @@ static void test_DxDiag_SystemInfo(void)
         {L"szProcessorEnglish", VT_BSTR},
     };
 
-    IDxDiagContainer *container;
+    IDxDiagContainer *container, *container2;
     HRESULT hr;
 
     if (!create_root_IDxDiagContainer())
@@ -828,6 +828,9 @@ static void test_DxDiag_SystemInfo(void)
         return;
     }
 
+    hr = IDxDiagContainer_GetChildContainer(pddc, L"", &container2);
+    ok(hr == E_INVALIDARG, "Expected IDxDiagContainer::GetChildContainer to return E_INVALIDARG, got 0x%08x\n", hr);
+
     hr = IDxDiagContainer_GetChildContainer(pddc, L"DxDiag_SystemInfo", &container);
     ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
 
@@ -835,6 +838,14 @@ static void test_DxDiag_SystemInfo(void)
     {
         trace("Testing container DxDiag_SystemInfo\n");
         test_container_properties(container, property_tests, ARRAY_SIZE(property_tests));
+
+        container2 = NULL;
+        hr = IDxDiagContainer_GetChildContainer(container, L"", &container2);
+        ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
+        ok(container2 != NULL, "Expected container2 != NULL\n");
+        ok(container2 != container, "Expected container != container2\n");
+
+        IDxDiagContainer_Release(container2);
         IDxDiagContainer_Release(container);
     }
 
@@ -954,8 +965,8 @@ static void test_DxDiag_SoundDevices(void)
 
     for (i = 0; i < count; i++)
     {
+        IDxDiagContainer *child, *child2;
         WCHAR child_container[256];
-        IDxDiagContainer *child;
 
         hr = IDxDiagContainer_EnumChildContainerNames(sound_cont, i, child_container, ARRAY_SIZE(child_container));
         ok(hr == S_OK, "Expected IDxDiagContainer::EnumChildContainerNames to return S_OK, got 0x%08x\n", hr);
@@ -966,6 +977,13 @@ static void test_DxDiag_SoundDevices(void)
         trace("Testing container %s\n", wine_dbgstr_w(child_container));
         test_container_properties(child, property_tests, ARRAY_SIZE(property_tests));
 
+        child2 = NULL;
+        hr = IDxDiagContainer_GetChildContainer(child, L"", &child2);
+        ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
+        ok(child2 != NULL, "Expected child2 != NULL\n");
+        ok(child2 != child, "Expected child != child2\n");
+
+        IDxDiagContainer_Release(child2);
         IDxDiagContainer_Release(child);
     }
 

--- a/dlls/dxdiagn/tests/container.c
+++ b/dlls/dxdiagn/tests/container.c
@@ -922,6 +922,110 @@ cleanup:
     IDxDiagProvider_Release(pddp);
 }
 
+static void test_DxDiag_SoundDevices(void)
+{
+    static const struct property_test property_tests[] =
+    {
+        {L"szDescription", VT_BSTR},
+        {L"szGuidDeviceID", VT_BSTR},
+        {L"szDriverName", VT_BSTR},
+        {L"szDriverPath", VT_BSTR},
+    };
+
+    IDxDiagContainer *sound_cont = NULL;
+    DWORD count, i;
+    HRESULT hr;
+
+    if (!create_root_IDxDiagContainer())
+    {
+        skip("Unable to create the root IDxDiagContainer\n");
+        return;
+    }
+
+    hr = IDxDiagContainer_GetChildContainer(pddc, L"DxDiag_DirectSound.DxDiag_SoundDevices", &sound_cont);
+    ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
+
+    hr = IDxDiagContainer_GetNumberOfProps(sound_cont, &count);
+    ok(hr == S_OK, "Expected IDxDiagContainer::GetNumberOfProps to return S_OK, got 0x%08x\n", hr);
+    ok(count == 0, "Expected count to be 0, got %u\n", count);
+
+    hr = IDxDiagContainer_GetNumberOfChildContainers(sound_cont, &count);
+    ok(hr == S_OK, "Expected IDxDiagContainer::GetNumberOfChildContainers to return S_OK, got 0x%08x\n", hr);
+
+    for (i = 0; i < count; i++)
+    {
+        WCHAR child_container[256];
+        IDxDiagContainer *child;
+
+        hr = IDxDiagContainer_EnumChildContainerNames(sound_cont, i, child_container, ARRAY_SIZE(child_container));
+        ok(hr == S_OK, "Expected IDxDiagContainer::EnumChildContainerNames to return S_OK, got 0x%08x\n", hr);
+
+        hr = IDxDiagContainer_GetChildContainer(sound_cont, child_container, &child);
+        ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
+
+        trace("Testing container %s\n", wine_dbgstr_w(child_container));
+        test_container_properties(child, property_tests, ARRAY_SIZE(property_tests));
+
+        IDxDiagContainer_Release(child);
+    }
+
+    IDxDiagContainer_Release(sound_cont);
+    IDxDiagContainer_Release(pddc);
+    IDxDiagProvider_Release(pddp);
+}
+
+static void test_DxDiag_SoundCaptureDevices(void)
+{
+    static const struct property_test property_tests[] =
+    {
+        {L"szDescription", VT_BSTR},
+        {L"szGuidDeviceID", VT_BSTR},
+        {L"szDriverName", VT_BSTR},
+        {L"szDriverPath", VT_BSTR},
+    };
+
+    IDxDiagContainer *sound_cont = NULL;
+    DWORD count, i;
+    HRESULT hr;
+
+    if (!create_root_IDxDiagContainer())
+    {
+        skip("Unable to create the root IDxDiagContainer\n");
+        return;
+    }
+
+    hr = IDxDiagContainer_GetChildContainer(pddc, L"DxDiag_DirectSound.DxDiag_SoundCaptureDevices", &sound_cont);
+    ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
+
+    hr = IDxDiagContainer_GetNumberOfProps(sound_cont, &count);
+    ok(hr == S_OK, "Expected IDxDiagContainer::GetNumberOfProps to return S_OK, got 0x%08x\n", hr);
+    ok(count == 0, "Expected count to be 0, got %u\n", count);
+
+    hr = IDxDiagContainer_GetNumberOfChildContainers(sound_cont, &count);
+    ok(hr == S_OK, "Expected IDxDiagContainer::GetNumberOfChildContainers to return S_OK, got 0x%08x\n", hr);
+
+    for (i = 0; i < count; i++)
+    {
+        WCHAR child_container[256];
+        IDxDiagContainer *child;
+
+        hr = IDxDiagContainer_EnumChildContainerNames(sound_cont, i, child_container, ARRAY_SIZE(child_container));
+        ok(hr == S_OK, "Expected IDxDiagContainer::EnumChildContainerNames to return S_OK, got 0x%08x\n", hr);
+
+        hr = IDxDiagContainer_GetChildContainer(sound_cont, child_container, &child);
+        ok(hr == S_OK, "Expected IDxDiagContainer::GetChildContainer to return S_OK, got 0x%08x\n", hr);
+
+        trace("Testing container %s\n", wine_dbgstr_w(child_container));
+        test_container_properties(child, property_tests, ARRAY_SIZE(property_tests));
+
+        IDxDiagContainer_Release(child);
+    }
+
+    IDxDiagContainer_Release(sound_cont);
+    IDxDiagContainer_Release(pddc);
+    IDxDiagProvider_Release(pddp);
+}
+
 START_TEST(container)
 {
     CoInitialize(NULL);
@@ -936,5 +1040,7 @@ START_TEST(container)
     test_root_children();
     test_DxDiag_SystemInfo();
     test_DxDiag_DisplayDevices();
+    test_DxDiag_SoundDevices();
+    test_DxDiag_SoundCaptureDevices();
     CoUninitialize();
 }


### PR DESCRIPTION
These commits fix a crash on startup in the game Tom Clancy's Rainbow Six: Lockdown. The relevant wine bugs are in the commit messages and the crash was also mentioned in https://github.com/ValveSoftware/Proton/issues/2862.