### PR TITLE
winevulkan: fshack cleanup + unwrap swapchain.

### DIFF
--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -192,7 +192,7 @@ FUNCTION_OVERRIDES = {
     "vkGetPhysicalDeviceWin32PresentationSupportKHR" : {"dispatch" : True, "driver" : True, "thunk" : True},
 
     # VK_KHR_swapchain
-    "vkAcquireNextImageKHR": {"dispatch" : True, "driver" : False, "thunk" : False},
+    "vkAcquireNextImageKHR": {"dispatch" : True, "driver" : False, "thunk" : True},
     "vkAcquireNextImage2KHR": {"dispatch" : True, "driver" : False, "thunk" : False},
     "vkCreateSwapchainKHR" : {"dispatch" : True, "driver" : True, "thunk" : False},
     "vkDestroySwapchainKHR" : {"dispatch" : True, "driver" : True, "thunk" : False},
@@ -955,6 +955,8 @@ class VkHandle(object):
     def native_handle(self, name):
         """ Provide access to the native handle of a wrapped object. """
 
+        if self.name == "VkSwapchainKHR":
+            return "((struct VkSwapchainKHR_T *)(uintptr_t) ({0}))->swapchain".format(name)
         if self.name == "VkCommandPool":
             return "wine_cmd_pool_from_handle({0})->command_pool".format(name)
         if self.name == "VkDebugUtilsMessengerEXT":

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -2216,13 +2216,6 @@ HRESULT WINAPI DllUnregisterServer(void)
     return S_OK;
 }
 
-VkResult WINAPI wine_vkAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex)
-{
-    struct VkSwapchainKHR_T *object = (struct VkSwapchainKHR_T *)(UINT_PTR)swapchain;
-    TRACE("%p, 0x%s, 0x%s, 0x%s, 0x%s, %p\n", device, wine_dbgstr_longlong(swapchain), wine_dbgstr_longlong(timeout), wine_dbgstr_longlong(semaphore), wine_dbgstr_longlong(fence), pImageIndex);
-    return device->funcs.p_vkAcquireNextImageKHR(device->device, object->swapchain, timeout, semaphore, fence, pImageIndex);
-}
-
 VkResult WINAPI wine_vkAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo, uint32_t *pImageIndex)
 {
 #if defined(USE_STRUCT_CONVERSION)
@@ -2667,6 +2660,7 @@ VkResult WINAPI wine_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCrea
         heap_free(object);
         return result;
     }
+    WINE_VK_ADD_NON_DISPATCHABLE_MAPPING(device->phys_dev->instance, object, object->swapchain);
 
     if(object->fs_hack_enabled){
         object->user_extent = pCreateInfo->imageExtent;
@@ -2675,6 +2669,7 @@ VkResult WINAPI wine_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCrea
         if(result != VK_SUCCESS){
             ERR("creating fs hack images failed: %d\n", result);
             device->funcs.p_vkDestroySwapchainKHR(device->device, object->swapchain, NULL);
+            WINE_VK_REMOVE_HANDLE_MAPPING(device->phys_dev->instance, object);
             heap_free(object);
             return result;
         }
@@ -2725,6 +2720,7 @@ void WINAPI wine_vkDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain
 
     device->funcs.p_vkDestroySwapchainKHR(device->device, object->swapchain, NULL);
 
+    WINE_VK_REMOVE_HANDLE_MAPPING(device->phys_dev->instance, object);
     heap_free(object);
 }
 

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -3026,9 +3026,6 @@ fail:
     for(i = 0; i < swapchain->n_images; ++i){
         struct fs_hack_image *hack = &swapchain->fs_hack_images[i];
 
-        device->funcs.p_vkFreeDescriptorSets(device->device, swapchain->descriptor_pool, 1, &hack->descriptor_set);
-        hack->descriptor_set = VK_NULL_HANDLE;
-
         device->funcs.p_vkDestroyImageView(device->device, hack->blit_view, NULL);
         hack->blit_view = VK_NULL_HANDLE;
 

--- a/dlls/winevulkan/vulkan_private.h
+++ b/dlls/winevulkan/vulkan_private.h
@@ -201,6 +201,8 @@ struct VkSwapchainKHR_T
     VkDescriptorSetLayout descriptor_set_layout;
     VkPipelineLayout pipeline_layout;
     VkPipeline pipeline;
+
+    struct wine_vk_mapping mapping;
 };
 
 struct wine_debug_utils_messenger

--- a/dlls/winevulkan/vulkan_private.h
+++ b/dlls/winevulkan/vulkan_private.h
@@ -82,11 +82,7 @@ struct VkDevice_T
 
     unsigned int quirks;
 
-    uint32_t num_swapchains;
-    struct VkSwapchainKHR_T **swapchains;
     VkQueueFamilyProperties *queue_props;
-
-    CRITICAL_SECTION swapchain_lock;
 
     struct wine_vk_mapping mapping;
 };
@@ -187,7 +183,6 @@ struct fs_hack_image
 
 struct VkSwapchainKHR_T
 {
-    struct wine_vk_base base;
     VkSwapchainKHR swapchain; /* native swapchain */
 
     /* fs hack data below */


### PR DESCRIPTION
Additionally to the other wrapped handles proton's winevulkan also wraps VkSwapchainKHR for fshack. Also includes some cleanup that was missed in past fshack changes.

The second commit needs regenerating with `./make_vulkan`. I wasn't about the preferred way for this repo, patches on wine-devel don't regenerate anything.