### PR TITLE
Add missing PROPVARIANT pos Fixes #106

### DIFF
--- a/dlls/mfreadwrite/tests/mfplat.c
+++ b/dlls/mfreadwrite/tests/mfplat.c
@@ -901,6 +901,7 @@ static void test_source_reader_from_media_source(void)
     LONGLONG timestamp;
     IMFAttributes *attributes;
     ULONG refcount;
+    PROPVARIANT pos;
     int i;
 
     source = create_test_source(3);


### PR DESCRIPTION
Doing minor correction to mfplat.c in function "test_source_reader_from_media_source(void)" by adding missing PROPVARIANT pos.