### PR TITLE
amd_ags_x64: Implement AGS 5.4.2, 6.0.0, 6.0.1

### DIFF
--- a/dlls/amd_ags_x64/amd_ags.h
+++ b/dlls/amd_ags_x64/amd_ags.h
@@ -151,7 +151,7 @@
 
 #define AMD_AGS_VERSION_MAJOR 6             ///< AGS major version
 #define AMD_AGS_VERSION_MINOR 0             ///< AGS minor version
-#define AMD_AGS_VERSION_PATCH 0             ///< AGS patch version
+#define AMD_AGS_VERSION_PATCH 1             ///< AGS patch version
 
 #ifdef __cplusplus
 extern "C" {
@@ -906,8 +906,8 @@ typedef struct AGSDX12ReturnedParams
             unsigned int        baseInstance : 1;                   ///< Supported in Radeon Software Version 20.2.1 onwards.
             unsigned int        getWaveSize : 1;                    ///< Supported in Radeon Software Version 20.5.1 onwards.
             unsigned int        floatConversion : 1;                ///< Supported in Radeon Software Version 20.5.1 onwards.
-            unsigned int        readLaneAt : 1;                     ///< Supported in Radeon Software Version 20.11.1 onwards.
-            unsigned int        rayHitToken : 1;                    ///< Supported in Radeon Software Version 20.11.1 onwards.
+            unsigned int        readLaneAt : 1;                     ///< Supported in Radeon Software Version 20.11.2 onwards.
+            unsigned int        rayHitToken : 1;                    ///< Supported in Radeon Software Version 20.11.2 onwards.
             unsigned int        padding : 20;                       ///< Reserved
         } ExtensionsSupported;
         ExtensionsSupported     extensionsSupported;                ///< List of supported extensions
@@ -1631,7 +1631,7 @@ AMD_AGS_API AGSReturnCode agsDriverExtensionsDX11_SetMaxAsyncCompileThreadCount(
 
 ///
 /// This method can be used to determine the total number of asynchronous shader compile jobs that are either
-/// queued for waiting for compilation or being compiled by the drivers asynchronous compilation threads.
+/// queued for waiting for compilation or being compiled by the driver's asynchronous compilation threads.
 /// This method can be called at any during the lifetime of the driver.
 ///
 /// \param [in] context                             Pointer to a context.

--- a/dlls/amd_ags_x64/amd_ags.h
+++ b/dlls/amd_ags_x64/amd_ags.h
@@ -34,6 +34,13 @@
 /// \endinternal
 ///
 /// ---------------------------------------
+/// What's new in AGS 5.4.2 since version 5.4.1
+/// ---------------------------------------
+/// AGS 5.4.2 includes the following updates:
+/// * sharedMemoryInBytes has been reinstated.
+/// * Clock speed returned for APUs.
+///
+/// ---------------------------------------
 /// What's new in AGS 5.4.1 since version 5.4.0
 /// ---------------------------------------
 /// AGS 5.4.1 includes the following updates:
@@ -130,7 +137,7 @@
 
 #define AMD_AGS_VERSION_MAJOR 5             ///< AGS major version
 #define AMD_AGS_VERSION_MINOR 4             ///< AGS minor version
-#define AMD_AGS_VERSION_PATCH 1             ///< AGS patch version
+#define AMD_AGS_VERSION_PATCH 2             ///< AGS patch version
 
 #ifdef __cplusplus
 extern "C" {
@@ -497,6 +504,43 @@ typedef struct AGSDeviceInfo_541
 
     int                             adlAdapterIndex;                ///< Internally used index into the ADL list of adapters
 } AGSDeviceInfo_541;
+
+/// The device info struct used to describe a physical GPU enumerated by AGS
+typedef struct AGSDeviceInfo_542
+{
+    const char*                     adapterString;                  ///< The adapter name string
+    AsicFamily                      asicFamily;                     ///< Set to Unknown if not AMD hardware
+    int                             isAPU;                          ///< Whether or not this is an APU
+    int                             vendorId;                       ///< The vendor id
+    int                             deviceId;                       ///< The device id
+    int                             revisionId;                     ///< The revision id
+
+    int                             numCUs;                         ///< Number of compute units.
+    int                             numWGPs;                        ///< Number of RDNA Work Group Processors.  Only valid if ASIC is RDNA onwards.
+
+    int                             numROPs;                        ///< Number of ROPs
+    int                             coreClock;                      ///< Core clock speed at 100% power in MHz
+    int                             memoryClock;                    ///< Memory clock speed at 100% power in MHz
+    int                             memoryBandwidth;                ///< Memory bandwidth in MB/s
+    float                           teraFlops;                      ///< Teraflops of GPU. Zero if not GCN onwards. Calculated from iCoreClock * iNumCUs * 64 Pixels/clk * 2 instructions/MAD
+
+    int                             isPrimaryDevice;                ///< Whether or not this is the primary adapter in the system. Not set on the WACK version.
+    unsigned long long              localMemoryInBytes;             ///< The size of local memory in bytes. 0 for non AMD hardware.
+    unsigned long long              sharedMemoryInBytes;            ///< The size of system memory available to the GPU in bytes.  It is important to factor this into your VRAM budget for APUs
+                                                                    ///< as the reported local memory will only be a small fraction of the total memory available to the GPU.
+
+    int                             numDisplays;                    ///< The number of active displays found to be attached to this adapter.
+    AGSDisplayInfo*                 displays;                       ///< List of displays allocated by AGS to be numDisplays in length.
+
+    int                             eyefinityEnabled;               ///< Indicates if Eyefinity is active
+    int                             eyefinityGridWidth;             ///< Contains width of the multi-monitor grid that makes up the Eyefinity Single Large Surface.
+    int                             eyefinityGridHeight;            ///< Contains height of the multi-monitor grid that makes up the Eyefinity Single Large Surface.
+    int                             eyefinityResolutionX;           ///< Contains width in pixels of the multi-monitor Single Large Surface.
+    int                             eyefinityResolutionY;           ///< Contains height in pixels of the multi-monitor Single Large Surface.
+    int                             eyefinityBezelCompensated;      ///< Indicates if bezel compensation is used for the current SLS display area. 1 if enabled, and 0 if disabled.
+
+    int                             adlAdapterIndex;                ///< Internally used index into the ADL list of adapters
+} AGSDeviceInfo_542;
 
 struct AGSDeviceInfo;
 

--- a/dlls/amd_ags_x64/amd_ags_x64.spec
+++ b/dlls/amd_ags_x64/amd_ags_x64.spec
@@ -1,4 +1,5 @@
 @ stdcall agsDeInit(ptr)
+@ stdcall agsDeInitialize(ptr)
 @ stdcall agsCheckDriverVersion(ptr long)
 @ stub agsDriverExtensionsDX11_BeginUAVOverlap
 @ stub agsDriverExtensionsDX11_CreateBuffer
@@ -38,5 +39,7 @@
 @ stub agsDriverExtensionsDX12_PushMarker
 @ stub agsDriverExtensionsDX12_SetMarker
 @ stdcall agsGetCrossfireGPUCount(ptr ptr)
+@ stdcall agsGetVersionNumber()
 @ stdcall agsInit(ptr ptr ptr)
+@ stdcall agsInitialize(long ptr ptr ptr)
 @ stub agsSetDisplayMode

--- a/dlls/amd_ags_x64/amd_ags_x64.spec
+++ b/dlls/amd_ags_x64/amd_ags_x64.spec
@@ -32,7 +32,7 @@
 @ stub agsDriverExtensionsDX12_CreateFromDevice
 @ stub agsDriverExtensionsDX12_DeInit
 @ stub agsDriverExtensionsDX12_Destroy
-@ stub agsDriverExtensionsDX12_DestroyDevice
+@ stdcall agsDriverExtensionsDX12_DestroyDevice(ptr ptr ptr)
 @ stub agsDriverExtensionsDX12_Init
 @ stub agsDriverExtensionsDX12_PopMarker
 @ stub agsDriverExtensionsDX12_PushMarker

--- a/dlls/amd_ags_x64/amd_ags_x64_main.c
+++ b/dlls/amd_ags_x64/amd_ags_x64_main.c
@@ -25,6 +25,7 @@ enum amd_ags_version
     AMD_AGS_VERSION_5_3_0,
     AMD_AGS_VERSION_5_4_0,
     AMD_AGS_VERSION_5_4_1,
+    AMD_AGS_VERSION_5_4_2,
 
     AMD_AGS_VERSION_COUNT
 };
@@ -44,17 +45,18 @@ amd_ags_info[AMD_AGS_VERSION_COUNT] =
     {5, 3, 0, sizeof(AGSDeviceInfo_520)},
     {5, 4, 0, sizeof(AGSDeviceInfo_540)},
     {5, 4, 1, sizeof(AGSDeviceInfo_541)},
+    {5, 4, 2, sizeof(AGSDeviceInfo_542)},
 };
 
 #define DEF_FIELD(name) {DEVICE_FIELD_##name, {offsetof(AGSDeviceInfo_511, name), offsetof(AGSDeviceInfo_520, name), \
         offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_540, name), \
-        offsetof(AGSDeviceInfo_541, name)}}
+        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name)}}
 #define DEF_FIELD_520_BELOW(name) {DEVICE_FIELD_##name, {offsetof(AGSDeviceInfo_511, name), offsetof(AGSDeviceInfo_520, name), \
         offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_520, name), -1, \
-        -1}}
+        -1, -1}}
 #define DEF_FIELD_540_UP(name) {DEVICE_FIELD_##name, {-1, -1, \
         -1, -1, offsetof(AGSDeviceInfo_540, name), \
-        offsetof(AGSDeviceInfo_541, name)}}
+        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name)}}
 
 #define DEVICE_FIELD_adapterString 0
 #define DEVICE_FIELD_architectureVersion 1

--- a/dlls/amd_ags_x64/amd_ags_x64_main.c
+++ b/dlls/amd_ags_x64/amd_ags_x64_main.c
@@ -27,6 +27,7 @@ enum amd_ags_version
     AMD_AGS_VERSION_5_4_1,
     AMD_AGS_VERSION_5_4_2,
     AMD_AGS_VERSION_6_0_0,
+    AMD_AGS_VERSION_6_0_1,
 
     AMD_AGS_VERSION_COUNT
 };
@@ -48,20 +49,24 @@ amd_ags_info[AMD_AGS_VERSION_COUNT] =
     {5, 4, 1, sizeof(AGSDeviceInfo_541)},
     {5, 4, 2, sizeof(AGSDeviceInfo_542)},
     {6, 0, 0, sizeof(AGSDeviceInfo_600)},
+    {6, 0, 1, sizeof(AGSDeviceInfo_600)},
 };
 
 #define DEF_FIELD(name) {DEVICE_FIELD_##name, {offsetof(AGSDeviceInfo_511, name), offsetof(AGSDeviceInfo_520, name), \
         offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_540, name), \
-        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name), offsetof(AGSDeviceInfo_600, name)}}
+        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name), offsetof(AGSDeviceInfo_600, name), \
+        offsetof(AGSDeviceInfo_600, name)}}
 #define DEF_FIELD_520_BELOW(name) {DEVICE_FIELD_##name, {offsetof(AGSDeviceInfo_511, name), offsetof(AGSDeviceInfo_520, name), \
         offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_520, name), -1, \
-        -1, -1, -1}}
+        -1, -1, -1, -1}}
 #define DEF_FIELD_540_UP(name) {DEVICE_FIELD_##name, {-1, -1, \
         -1, -1, offsetof(AGSDeviceInfo_540, name), \
-        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name), offsetof(AGSDeviceInfo_600, name)}}
+        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name), offsetof(AGSDeviceInfo_600, name), \
+        offsetof(AGSDeviceInfo_600, name)}}
 #define DEF_FIELD_600_BELOW(name) {DEVICE_FIELD_##name, {offsetof(AGSDeviceInfo_511, name), offsetof(AGSDeviceInfo_520, name), \
         offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_520, name), offsetof(AGSDeviceInfo_540, name), \
-        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name), -1}}
+        offsetof(AGSDeviceInfo_541, name), offsetof(AGSDeviceInfo_542, name), -1, \
+        -1}}
 
 #define DEVICE_FIELD_adapterString 0
 #define DEVICE_FIELD_architectureVersion 1

--- a/dlls/amd_ags_x64/amd_ags_x64_main.c
+++ b/dlls/amd_ags_x64/amd_ags_x64_main.c
@@ -9,6 +9,7 @@
 
 #include "wine/vulkan.h"
 
+#define COBJMACROS
 #include "d3d11.h"
 #include "d3d12.h"
 
@@ -533,6 +534,20 @@ AGSReturnCode WINAPI agsDriverExtensionsDX12_CreateDevice(AGSContext *context,
     }
 
     TRACE("Created d3d12 device %p.\n", returned_params->pDevice);
+
+    return AGS_SUCCESS;
+}
+
+AGSReturnCode WINAPI agsDriverExtensionsDX12_DestroyDevice(AGSContext* context, ID3D12Device* device, unsigned int* device_refs)
+{
+    ULONG ref_count;
+
+    if (!device)
+        return AGS_SUCCESS;
+
+    ref_count = ID3D12Device_Release(device);
+    if (device_refs)
+        *device_refs = (unsigned int)ref_count;
 
     return AGS_SUCCESS;
 }


### PR DESCRIPTION
I implemented this to see if it would have any impact on RE8 deciding to be more friendly with its graphics options, but alas, it did not.

Feels bad to let it go to waste though...