### PR TITLE
loader: Set default regkey for NVIDIA NGX FullPath

### DIFF
--- a/loader/wine.inf.in
+++ b/loader/wine.inf.in
@@ -74,7 +74,8 @@ AddReg=\
     Timezones,\
     VersionInfo,\
     LicenseInformation, \
-    SteamClient
+    SteamClient, \
+    NVIDIANGX
 
 [DefaultInstall.ntamd64]
 RegisterDlls=RegisterDllsSection
@@ -102,7 +103,8 @@ AddReg=\
     Timezones,\
     VersionInfo.ntamd64,\
     LicenseInformation, \
-    SteamClient.ntamd64
+    SteamClient.ntamd64, \
+    NVIDIANGX
 
 [DefaultInstall.ntarm64]
 RegisterDlls=RegisterDllsSection
@@ -145,7 +147,8 @@ AddReg=\
     Tapi,\
     VersionInfo.ntamd64,\
     LicenseInformation, \
-    SteamClient.ntamd64
+    SteamClient.ntamd64, \
+    NVIDIANGX
 
 [Wow64Install.ntarm64]
 WineFakeDlls=FakeDllsWin32
@@ -4261,3 +4264,6 @@ HKCU,Software\Wine\DllOverrides,"ucrtbase",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"vcomp140",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"vcruntime140",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"atiadlxx",,"disabled"
+
+[NVIDIANGX]
+HKLM,Software\NVIDIA Corporation\Global\NGXCore,"FullPath",,"C:\Windows\System32"


### PR DESCRIPTION
Sets the default location for the NVIDIA NGX SDK search-path to be
C:\Windows\System32\

This is required for supporting NVIDIA DLSS within Proton.