### PR TITLE
Report a non-zero value in dwFFDriverVersion for haptic devices (fixes force feedback effects in WRC8)

### DIFF
--- a/dlls/dinput/joystick_sdl.c
+++ b/dlls/dinput/joystick_sdl.c
@@ -1144,9 +1144,6 @@ static JoystickImpl *alloc_device(REFGUID rguid, IDirectInputImpl *dinput, unsig
         }
     }
 
-    if (newDevice->sdldev->sdl_haptic)
-        newDevice->generic.devcaps.dwFlags |= DIDC_FORCEFEEDBACK;
-
     newDevice->generic.base.data_format.wine_df = df;
 
     /* Fill the caps */

--- a/dlls/dinput/joystick_sdl.c
+++ b/dlls/dinput/joystick_sdl.c
@@ -1158,8 +1158,12 @@ static JoystickImpl *alloc_device(REFGUID rguid, IDirectInputImpl *dinput, unsig
     newDevice->generic.devcaps.dwDevType = ddi.dwDevType;
 
     if (newDevice->sdldev->sdl_haptic)
+    {
         newDevice->generic.devcaps.dwFlags |= DIDC_FORCEFEEDBACK;
 
+	/* Some games expect a non-zero value to enable FF */
+        newDevice->generic.devcaps.dwFFDriverVersion = 1;
+    }
     IDirectInput_AddRef(&newDevice->generic.base.dinput->IDirectInput7A_iface);
 
     return newDevice;


### PR DESCRIPTION
Hi,

The first patch fixes one of the issues with the game WRC 8 (tracked in [#4567)](https://github.com/ValveSoftware/Proton/issues/4567). It seems that the game assumes no force feedback enabled driver is loaded if dwFFDriverVersion is zero, and refuses to enable any force feedback effects. Settings this to a non-zero value enables the effects.

I'm not sure if any game check the actual driver version. If so I assume this needs to be revisited and report a device specific value matching the Windows driver?

The game WRC 9 have the same problem and fix. This game will release on Steam next month. Confirmed the fix with a copy of the game from another store.

---

The second patch removes a seemingly superfluous call to set the DIDC_FORCEFEEDBACK flag a second time. I'm less sure about this one, but the final dwFlags value seems unchanged for the games I tried with and without this change.
