### PR TITLE
wine.inf: Use native xinput1_3 for WRC10.

### DIFF
--- a/loader/wine.inf.in
+++ b/loader/wine.inf.in
@@ -4236,6 +4236,7 @@ HKCU,Software\Wine\AppDefaults\ShadowOfWar.exe\DllOverrides,"atiadlxx",,"builtin
 HKCU,Software\Wine\AppDefaults\ShadowOfWar.exe\DllOverrides,"amd_ags_x64",,""
 HKCU,Software\Wine\AppDefaults\DIRT5.exe\DllOverrides,"atiadlxx",,"builtin"
 HKCU,Software\Wine\AppDefaults\WRC8.exe\DllOverrides,"xinput1_3",,"native"
+HKCU,Software\Wine\AppDefaults\WRC10.exe\DllOverrides,"xinput1_3",,"native"
 ;;Likely want *80 and *90 too, but those require removing Wine's manifest files.
 HKCU,Software\Wine\DllOverrides,"atl100",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"msvcp100",0x2,"native,builtin"


### PR DESCRIPTION
Hi,

Here's a trivial PR to set xinput1_3 to native for the game WRC10 too. 

It has the same issues as WRC8 discussed in #121, with the added problem that it defaults to, and crashes with, DX12. See issue [#5143.](https://github.com/ValveSoftware/Proton/issues/5143) 
