### PR TITLE
kernelbase: Don't pass StdHandles with CREATE_NEW_CONSOLE.

### DIFF
--- a/dlls/kernelbase/process.c
+++ b/dlls/kernelbase/process.c
@@ -203,7 +203,7 @@ static RTL_USER_PROCESS_PARAMETERS *create_process_params( const WCHAR *filename
         params->hStdOutput = startup->hStdOutput;
         params->hStdError  = startup->hStdError;
     }
-    else if (flags & DETACHED_PROCESS)
+    else if (flags & (DETACHED_PROCESS | CREATE_NEW_CONSOLE))
     {
         params->hStdInput  = INVALID_HANDLE_VALUE;
         params->hStdOutput = INVALID_HANDLE_VALUE;


### PR DESCRIPTION
Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=51264

This patch (accepted to Wine 6.12) fixes an annoying (but harmless) crash in the Elite Dangerous launcher.

I'm not sure if experimental is the right branch to raise a PR against; so please let me know if I should be raising against another.

Signed-off-by: Brendan McGrath <brendan@redmandi.com>
Signed-off-by: Jacek Caban <jacek@codeweavers.com>
Signed-off-by: Alexandre Julliard <julliard@winehq.org>