### PR TITLE
ntdll/fsync: Support only futex_waitv() API

### DIFF
--- a/dlls/ntdll/unix/fsync.c
+++ b/dlls/ntdll/unix/fsync.c
@@ -59,6 +59,10 @@ WINE_DEFAULT_DEBUG_CHANNEL(fsync);
 #include "pshpack4.h"
 #include "poppack.h"
 
+#define FUTEX_WAIT_BITSET	9
+#define FUTEX_CLOCK_REALTIME	256
+#define FUTEX_BITSET_MATCH_ANY	0xffffffff
+
 /* futex_waitv interface */
 
 #ifndef __NR_futex_waitv
@@ -137,11 +141,13 @@ static inline int futex_wait( int *addr, int val, const ULONGLONG *end )
 {
     if (end)
     {
-        LONGLONG timeleft = update_timeout( *end );
         struct timespec timeout;
-        timeout.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
-        timeout.tv_nsec = (timeleft % TICKSPERSEC) * 100;
-        return syscall( __NR_futex, addr, 0, val, &timeout, 0, 0 );
+        ULONGLONG tmp = *end - SECS_1601_TO_1970 * TICKSPERSEC;
+        timeout.tv_sec = tmp / (ULONGLONG)TICKSPERSEC;
+        timeout.tv_nsec = (tmp % TICKSPERSEC) * 100;
+
+        return syscall( __NR_futex, addr, FUTEX_WAIT_BITSET | FUTEX_CLOCK_REALTIME,
+			val, &timeout, 0, FUTEX_BITSET_MATCH_ANY );
     }
     else
     {

--- a/dlls/ntdll/unix/fsync.c
+++ b/dlls/ntdll/unix/fsync.c
@@ -980,10 +980,18 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
                 tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
                 tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
 
-                ret = futex_wait_multiple( futexes, waitcount, &tmo_p );
+                if (waitcount == 1)
+                    ret = futex_wait( futexes[0].addr, futexes[0].val, &tmo_p );
+                else
+                    ret = futex_wait_multiple( futexes, waitcount, &tmo_p );
             }
             else
-                ret = futex_wait_multiple( futexes, waitcount, NULL );
+            {
+                if (waitcount == 1)
+                    ret = futex_wait( futexes[0].addr, futexes[0].val, NULL );
+                else
+                    ret = futex_wait_multiple( futexes, waitcount, NULL );
+            }
 
             /* FUTEX_WAIT_MULTIPLE can succeed or return -EINTR, -EAGAIN,
              * -EFAULT/-EACCES, -ETIMEDOUT. In the first three cases we need to

--- a/dlls/ntdll/unix/fsync.c
+++ b/dlls/ntdll/unix/fsync.c
@@ -76,10 +76,32 @@ static inline void small_pause(void)
 #endif
 }
 
-static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
-        int count, const struct timespec *timeout )
+static LONGLONG update_timeout( ULONGLONG end )
 {
-    return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
+    LARGE_INTEGER now;
+    LONGLONG timeleft;
+
+    NtQuerySystemTime( &now );
+    timeleft = end - now.QuadPart;
+    if (timeleft < 0) timeleft = 0;
+    return timeleft;
+}
+
+static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
+        int count, const ULONGLONG *end )
+{
+   if (end)
+   {
+        LONGLONG timeleft = update_timeout( *end );
+        struct timespec timeout;
+        timeout.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
+        timeout.tv_nsec = (timeleft % TICKSPERSEC) * 100;
+        return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
+   }
+   else
+   {
+        return syscall( __NR_futex, futexes, 31, count, NULL, 0, 0 );
+   }
 }
 
 static inline int futex_wake( int *addr, int val )
@@ -87,9 +109,20 @@ static inline int futex_wake( int *addr, int val )
     return syscall( __NR_futex, addr, 1, val, NULL, 0, 0 );
 }
 
-static inline int futex_wait( int *addr, int val, struct timespec *timeout )
+static inline int futex_wait( int *addr, int val, const ULONGLONG *end )
 {
-    return syscall( __NR_futex, addr, 0, val, timeout, 0, 0 );
+    if (end)
+    {
+        LONGLONG timeleft = update_timeout( *end );
+        struct timespec timeout;
+        timeout.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
+        timeout.tv_nsec = (timeleft % TICKSPERSEC) * 100;
+        return syscall( __NR_futex, addr, 0, val, &timeout, 0, 0 );
+    }
+    else
+    {
+        return syscall( __NR_futex, addr, 0, val, NULL, 0, 0 );
+    }
 }
 
 static unsigned int spincount = 100;
@@ -645,17 +678,6 @@ NTSTATUS fsync_query_mutex( HANDLE handle, void *info, ULONG *ret_len )
     return STATUS_SUCCESS;
 }
 
-static LONGLONG update_timeout( ULONGLONG end )
-{
-    LARGE_INTEGER now;
-    LONGLONG timeleft;
-
-    NtQuerySystemTime( &now );
-    timeleft = end - now.QuadPart;
-    if (timeleft < 0) timeleft = 0;
-    return timeleft;
-}
-
 static NTSTATUS do_single_wait( int *addr, int val, ULONGLONG *end, BOOLEAN alertable )
 {
     int ret;
@@ -677,32 +699,14 @@ static NTSTATUS do_single_wait( int *addr, int val, ULONGLONG *end, BOOLEAN aler
 #endif
         futexes[0].bitset = futexes[1].bitset = ~0;
 
-        if (end)
-        {
-            LONGLONG timeleft = update_timeout( *end );
-            struct timespec tmo_p;
-            tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
-            tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
-            ret = futex_wait_multiple( futexes, 2, &tmo_p );
-        }
-        else
-            ret = futex_wait_multiple( futexes, 2, NULL );
+        ret = futex_wait_multiple( futexes, 2, end );
 
         if (__atomic_load_n( apc_futex, __ATOMIC_SEQ_CST ))
             return STATUS_USER_APC;
     }
     else
     {
-        if (end)
-        {
-            LONGLONG timeleft = update_timeout( *end );
-            struct timespec tmo_p;
-            tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
-            tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
-            ret = futex_wait( addr, val, &tmo_p );
-        }
-        else
-            ret = futex_wait( addr, val, NULL );
+        ret = futex_wait( addr, val, end );
     }
 
     if (!ret)
@@ -973,25 +977,11 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
                 TRACE("Wait timed out.\n");
                 return STATUS_TIMEOUT;
             }
-            else if (timeout)
-            {
-                LONGLONG timeleft = update_timeout( end );
-                struct timespec tmo_p;
-                tmo_p.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
-                tmo_p.tv_nsec = (timeleft % TICKSPERSEC) * 100;
 
-                if (waitcount == 1)
-                    ret = futex_wait( futexes[0].addr, futexes[0].val, &tmo_p );
-                else
-                    ret = futex_wait_multiple( futexes, waitcount, &tmo_p );
-            }
+            if (waitcount == 1)
+                ret = futex_wait( futexes[0].addr, futexes[0].val, timeout ? &end : NULL );
             else
-            {
-                if (waitcount == 1)
-                    ret = futex_wait( futexes[0].addr, futexes[0].val, NULL );
-                else
-                    ret = futex_wait_multiple( futexes, waitcount, NULL );
-            }
+                ret = futex_wait_multiple( futexes, waitcount, timeout ? &end : NULL );
 
             /* FUTEX_WAIT_MULTIPLE can succeed or return -EINTR, -EAGAIN,
              * -EFAULT/-EACCES, -ETIMEDOUT. In the first three cases we need to

--- a/dlls/ntdll/unix/fsync.c
+++ b/dlls/ntdll/unix/fsync.c
@@ -41,6 +41,7 @@
 # include <sys/syscall.h>
 #endif
 #include <unistd.h>
+#include <stdint.h>
 
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
@@ -56,16 +57,30 @@
 WINE_DEFAULT_DEBUG_CHANNEL(fsync);
 
 #include "pshpack4.h"
-struct futex_wait_block
-{
-    int *addr;
-#if __SIZEOF_POINTER__ == 4
-    int pad;
-#endif
-    int val;
-    int bitset;
-};
 #include "poppack.h"
+
+/* futex_waitv interface */
+
+#ifndef __NR_futex_waitv
+
+# define __NR_futex_waitv 449
+# define FUTEX_32 2
+struct futex_waitv {
+    uint64_t   val;
+    uint64_t   uaddr;
+    uint32_t   flags;
+    uint32_t __reserved;
+};
+
+#endif
+
+#define u64_to_ptr(x) (void *)(uintptr_t)(x)
+
+struct timespec64
+{
+    long long tv_sec;
+    long long tv_nsec;
+};
 
 static inline void small_pause(void)
 {
@@ -87,20 +102,29 @@ static LONGLONG update_timeout( ULONGLONG end )
     return timeleft;
 }
 
-static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
+static inline void futex_vector_set( struct futex_waitv *waitv, int *addr, int val )
+{
+    waitv->uaddr = (uintptr_t) addr;
+    waitv->val = val;
+    waitv->flags = FUTEX_32;
+    waitv->__reserved = 0;
+}
+
+static inline int futex_wait_multiple( const struct futex_waitv *futexes,
         int count, const ULONGLONG *end )
 {
    if (end)
    {
-        LONGLONG timeleft = update_timeout( *end );
-        struct timespec timeout;
-        timeout.tv_sec = timeleft / (ULONGLONG)TICKSPERSEC;
-        timeout.tv_nsec = (timeleft % TICKSPERSEC) * 100;
-        return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
+        struct timespec64 timeout;
+        ULONGLONG tmp = *end - SECS_1601_TO_1970 * TICKSPERSEC;
+        timeout.tv_sec = tmp / (ULONGLONG)TICKSPERSEC;
+        timeout.tv_nsec = (tmp % TICKSPERSEC) * 100;
+
+        return syscall( __NR_futex_waitv, futexes, count, 0, &timeout, CLOCK_REALTIME );
    }
    else
    {
-        return syscall( __NR_futex, futexes, 31, count, NULL, 0, 0 );
+        return syscall( __NR_futex_waitv, futexes, count, 0, NULL, 0 );
    }
 }
 
@@ -134,8 +158,7 @@ int do_fsync(void)
 
     if (do_fsync_cached == -1)
     {
-        static const struct timespec zero;
-        futex_wait_multiple( NULL, 0, &zero );
+        syscall( __NR_futex_waitv, NULL, 0, 0, NULL, 0 );
         do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
         if (getenv("WINEFSYNC_SPINCOUNT"))
             spincount = atoi(getenv("WINEFSYNC_SPINCOUNT"));
@@ -685,19 +708,13 @@ static NTSTATUS do_single_wait( int *addr, int val, ULONGLONG *end, BOOLEAN aler
     if (alertable)
     {
         int *apc_futex = ntdll_get_thread_data()->fsync_apc_futex;
-        struct futex_wait_block futexes[2];
+        struct futex_waitv futexes[2];
 
         if (__atomic_load_n( apc_futex, __ATOMIC_SEQ_CST ))
             return STATUS_USER_APC;
 
-        futexes[0].addr = addr;
-        futexes[0].val = val;
-        futexes[1].addr = apc_futex;
-        futexes[1].val = 0;
-#if __SIZEOF_POINTER__ == 4
-        futexes[0].pad = futexes[1].pad = 0;
-#endif
-        futexes[0].bitset = futexes[1].bitset = ~0;
+        futex_vector_set( &futexes[0], addr, val );
+        futex_vector_set( &futexes[1], apc_futex, 0 );
 
         ret = futex_wait_multiple( futexes, 2, end );
 
@@ -722,7 +739,7 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
 {
     static const LARGE_INTEGER zero = {0};
 
-    struct futex_wait_block futexes[MAXIMUM_WAIT_OBJECTS + 1];
+    struct futex_waitv futexes[MAXIMUM_WAIT_OBJECTS + 1];
     struct fsync *objs[MAXIMUM_WAIT_OBJECTS];
     int has_fsync = 0, has_server = 0;
     BOOL msgwait = FALSE;
@@ -852,8 +869,7 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
                             small_pause();
                         }
 
-                        futexes[i].addr = &semaphore->count;
-                        futexes[i].val = 0;
+                        futex_vector_set( &futexes[i], &semaphore->count, 0 );
                         break;
                     }
                     case FSYNC_MUTEX:
@@ -885,8 +901,7 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
                             small_pause();
                         }
 
-                        futexes[i].addr = &mutex->tid;
-                        futexes[i].val  = tid;
+                        futex_vector_set( &futexes[i], &mutex->tid, tid );
                         break;
                     }
                     case FSYNC_AUTO_EVENT:
@@ -907,8 +922,7 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
                             small_pause();
                         }
 
-                        futexes[i].addr = &event->signaled;
-                        futexes[i].val = 0;
+                        futex_vector_set( &futexes[i], &event->signaled, 0 );
                         break;
                     }
                     case FSYNC_MANUAL_EVENT:
@@ -930,8 +944,7 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
                             small_pause();
                         }
 
-                        futexes[i].addr = &event->signaled;
-                        futexes[i].val = 0;
+                        futex_vector_set( &futexes[i], &event->signaled, 0 );
                         break;
                     }
                     default:
@@ -942,26 +955,14 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
                 else
                 {
                     /* Avoid breaking things entirely. */
-                    futexes[i].addr = &dummy_futex;
-                    futexes[i].val = dummy_futex;
+                    futex_vector_set( &futexes[i], &dummy_futex, dummy_futex );
                 }
-
-#if __SIZEOF_POINTER__ == 4
-                futexes[i].pad = 0;
-#endif
-                futexes[i].bitset = ~0;
             }
 
             if (alertable)
             {
                 /* We already checked if it was signaled; don't bother doing it again. */
-                futexes[i].addr = ntdll_get_thread_data()->fsync_apc_futex;
-                futexes[i].val = 0;
-#if __SIZEOF_POINTER__ == 4
-                futexes[i].pad = 0;
-#endif
-                futexes[i].bitset = ~0;
-                i++;
+                futex_vector_set( &futexes[i++], ntdll_get_thread_data()->fsync_apc_futex, 0 );
             }
             waitcount = i;
 
@@ -979,7 +980,7 @@ static NTSTATUS __fsync_wait_objects( DWORD count, const HANDLE *handles,
             }
 
             if (waitcount == 1)
-                ret = futex_wait( futexes[0].addr, futexes[0].val, timeout ? &end : NULL );
+                ret = futex_wait( u64_to_ptr(futexes[0].uaddr), futexes[0].val, timeout ? &end : NULL );
             else
                 ret = futex_wait_multiple( futexes, waitcount, timeout ? &end : NULL );
 

--- a/server/fsync.c
+++ b/server/fsync.c
@@ -47,21 +47,11 @@
 #include "fsync.h"
 
 #include "pshpack4.h"
-struct futex_wait_block
-{
-    int *addr;
-#if __SIZEOF_POINTER__ == 4
-    int pad;
-#endif
-    int val;
-};
 #include "poppack.h"
 
-static inline int futex_wait_multiple( const struct futex_wait_block *futexes,
-        int count, const struct timespec *timeout )
-{
-    return syscall( __NR_futex, futexes, 31, count, timeout, 0, 0 );
-}
+#ifndef __NR_futex_waitv
+#define __NR_futex_waitv 449
+#endif
 
 int do_fsync(void)
 {
@@ -70,8 +60,7 @@ int do_fsync(void)
 
     if (do_fsync_cached == -1)
     {
-        static const struct timespec zero;
-        futex_wait_multiple( NULL, 0, &zero );
+        syscall( __NR_futex_waitv, 0, 0, 0, 0, 0);
         do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
     }
 


### PR DESCRIPTION
Since an interface for wait on multiple futexes was merged, we no longer need to support different interfaces. Drop out FUTEX_WAIT_MULTIPLE (opcode 31) and old futex2 interface (with futex2_wake/wait) in favor of the interface accepted by upstream Linux.

If an user uses Proton with a kernel with a different futex interface, it's unsupported and the Wine will fallback to use esync. The futex_waitv() interface will be released at Linux 5.16, but users can apply backports to custom kernels with patches available here: https://github.com/andrealmeid/futex_waitv_patches