### PR TITLE
winebus.sys: Fix container detection

### DIFF
--- a/dlls/winebus.sys/bus_udev.c
+++ b/dlls/winebus.sys/bus_udev.c
@@ -2098,7 +2098,7 @@ NTSTATUS udev_bus_init(void *args)
         goto error;
     }
 
-    if (access("/run/pressure-vessel", R_OK) || access("/.flatpak-info", R_OK))
+    if (access("/run/pressure-vessel", R_OK) == 0 || access("/.flatpak-info", R_OK) == 0)
     {
         TRACE("Container detected, bypassing udevd by default\n");
         options.disable_udevd = TRUE;


### PR DESCRIPTION
msvcrt 'access' will return 0 if the file is present and readable