### PR TITLE
file: add env var to skip searching directories when opening files

### DIFF
--- a/dlls/ntdll/unix/file.c
+++ b/dlls/ntdll/unix/file.c
@@ -3188,6 +3188,17 @@ static NTSTATUS lookup_unix_name( const WCHAR *name, int name_len, char **buffer
     if (is_unix && (disposition == FILE_OPEN || disposition == FILE_OVERWRITE))
         return STATUS_OBJECT_NAME_NOT_FOUND;
 
+    static int skip_search = -1;
+    if (skip_search == -1)
+    {
+        const char *env_var;
+
+        if ((skip_search = (env_var = getenv("WINE_NO_OPEN_FILE_SEARCH")) && atoi(env_var)))
+            WARN("Disabling case insensitive search for opening files");
+    }
+    if (skip_search && disposition == FILE_OPEN)
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+
     /* now do it component by component */
 
     while (name_len)


### PR DESCRIPTION
Certain applications attempt to load lots of small files, which causes huge performance issues when the files are not present as wine currently has to search the directory to check if a file exists. This patch adds an env var that skips the searching behavior ONLY when opening files.

I don't know if this is the correct way to add something like this, or if the naming scheme is correct (`WINE_CASE_SENSITIVE_OPEN_FILES` is technically more correct than `WINE_NO_OPEN_FILE_SEARCH` albeit a bit too long).

This fixes most performance issues with Phantasy Star Online 2 New Genesis: see [Proton/#4122](https://github.com/ValveSoftware/Proton/issues/4122)