### PR TITLE
qedit: Do not force the sample to be freed in SampleGrabber_callback().

### DIFF
--- a/dlls/qedit/samplegrabber.c
+++ b/dlls/qedit/samplegrabber.c
@@ -164,9 +164,6 @@ static void SampleGrabber_callback(struct sample_grabber *This, IMediaSample *sa
 		if (ref)
 		{
 		    ERR("(%p) Callback referenced sample %p by %lu\n", This, sample, ref);
-		    /* ugly as hell but some apps are sooo buggy */
-		    while (ref--)
-			IMediaSample_Release(sample);
 		}
 	    }
             break;


### PR DESCRIPTION
This patch removes a work around that causes a crash in Unravel Two. [#3962](https://github.com/ValveSoftware/Proton/issues/3962)

There is a callback in Unravel Two that appears to add a reference to a
IMediaSample, which this workaround treats as a leak and releases. However, the
application also later releases the reference itself, causing a use-after-free.

Note that this patch was recently accepted upstream to Wine.