### PR TITLE
Backport "ntdll: Implement RtlRestoreContext on i386."

### DIFF
--- a/dlls/kernel32/kernel32.spec
+++ b/dlls/kernel32/kernel32.spec
@@ -1316,7 +1316,7 @@
 @ stdcall RtlMoveMemory(ptr ptr long) NTDLL.RtlMoveMemory
 @ stdcall RtlPcToFileHeader(ptr ptr) NTDLL.RtlPcToFileHeader
 @ stdcall -arch=arm,arm64,x86_64 -norelay RtlRaiseException(ptr) NTDLL.RtlRaiseException
-@ cdecl -arch=arm,arm64,x86_64 -import RtlRestoreContext(ptr ptr)
+@ cdecl -import RtlRestoreContext(ptr ptr)
 @ stdcall RtlUnwind(ptr ptr ptr long) NTDLL.RtlUnwind
 @ stdcall -arch=arm,arm64,x86_64 RtlUnwindEx(long long ptr long ptr) NTDLL.RtlUnwindEx
 @ stdcall -arch=arm,arm64,x86_64 RtlVirtualUnwind(long long long ptr ptr ptr ptr ptr) NTDLL.RtlVirtualUnwind

--- a/dlls/ntdll/ntdll.spec
+++ b/dlls/ntdll/ntdll.spec
@@ -944,7 +944,7 @@
 @ stdcall RtlRemoveVectoredContinueHandler(ptr)
 @ stdcall RtlRemoveVectoredExceptionHandler(ptr)
 @ stdcall RtlResetRtlTranslations(ptr)
-@ cdecl -arch=arm,arm64,x86_64 RtlRestoreContext(ptr ptr)
+@ cdecl RtlRestoreContext(ptr ptr)
 @ stdcall RtlRestoreLastWin32Error(long) RtlSetLastWin32Error
 @ stub RtlRevertMemoryStream
 @ stub RtlRunDecodeUnicodeString

--- a/dlls/ntdll/signal_i386.c
+++ b/dlls/ntdll/signal_i386.c
@@ -342,6 +342,14 @@ __ASM_STDCALL_FUNC( RtlCaptureContext, 4,
                     __ASM_CFI(".cfi_adjust_cfa_offset -4\n\t")
                     "ret $4" )
 
+/*******************************************************************
+ *              RtlRestoreContext (NTDLL.@)
+ */
+void CDECL RtlRestoreContext( CONTEXT *context, EXCEPTION_RECORD *rec )
+{
+    TRACE( "returning to %p stack %p\n", (void *)context->Eip, (void *)context->Esp );
+    NtContinue( context, FALSE );
+}
 
 /*******************************************************************
  *		RtlUnwind (NTDLL.@)


### PR DESCRIPTION
This commit was added to Wine 7.16: https://github.com/wine-mirror/wine/commit/88d13e663d1e6d797b4ea74a80a6e97e418e37f4

This commit fixes the BepInEx modloader on 32-bit IL2CPP Unity games like Among Us which would otherwise crash when a garbage collection cycle runs. Recent builds of BepInEx have switched from Mono to CoreCLR, which introduced this issue. BepInEx has built in a detection whether this patch is present: https://github.com/BepInEx/BepInEx/commit/a77efac44b8a94bf953b544b0508248894212d12#diff-dbb9378de52cf55fc473d0293ac660901f9b0b744d54081f9f23cc30f6e668e8R57

I've built Proton locally and confirmed that this commit builds and fixes the issue.