### PR TITLE
winebus.sys: Enable hidraw for Simucube racing wheels and Fanatec pedals.

### DIFF
--- a/dlls/winebus.sys/bus_udev.c
+++ b/dlls/winebus.sys/bus_udev.c
@@ -1695,7 +1695,8 @@ static void udev_add_device(struct udev_device *dev, int fd)
         memcpy(desc.serialnumber, zeros, sizeof(zeros));
     }
 
-    if (!is_dualshock4_gamepad(desc.vid, desc.pid) && !is_dualsense_gamepad(desc.vid, desc.pid) && !is_thrustmaster_hotas(desc.vid, desc.pid))
+    if (!is_dualshock4_gamepad(desc.vid, desc.pid) && !is_dualsense_gamepad(desc.vid, desc.pid) && !is_thrustmaster_hotas(desc.vid, desc.pid) &&
+        !is_simucube_wheel(desc.vid, desc.pid) && !is_fanatec_pedals(desc.vid, desc.pid))
     {
         TRACE("hidraw %s: deferring %s to a different backend\n", debugstr_a(devnode), debugstr_device_desc(&desc));
         close(fd);

--- a/dlls/winebus.sys/unix_private.h
+++ b/dlls/winebus.sys/unix_private.h
@@ -286,5 +286,7 @@ BOOL is_dualshock4_gamepad(WORD vid, WORD pid) DECLSPEC_HIDDEN;
 BOOL is_dualsense_gamepad(WORD vid, WORD pid) DECLSPEC_HIDDEN;
 BOOL is_logitech_g920(WORD vid, WORD pid) DECLSPEC_HIDDEN;
 BOOL is_thrustmaster_hotas(WORD vid, WORD pid) DECLSPEC_HIDDEN;
+BOOL is_simucube_wheel(WORD vid, WORD pid) DECLSPEC_HIDDEN;
+BOOL is_fanatec_pedals(WORD vid, WORD pid) DECLSPEC_HIDDEN;
 
 #endif /* __WINEBUS_UNIX_PRIVATE_H */

--- a/dlls/winebus.sys/unixlib.c
+++ b/dlls/winebus.sys/unixlib.c
@@ -110,6 +110,24 @@ BOOL is_thrustmaster_hotas(WORD vid, WORD pid)
     return vid == 0x044F && (pid == 0xB679 || pid == 0xB687 || pid == 0xB10A);
 }
 
+BOOL is_simucube_wheel(WORD vid, WORD pid)
+{
+    if (vid != 0x16D0) return FALSE;
+    if (pid == 0x0D61) return TRUE; /* Simucube 2 Sport */
+    if (pid == 0x0D60) return TRUE; /* Simucube 2 Pro */
+    if (pid == 0x0D5F) return TRUE; /* Simucube 2 Ultimate */
+    if (pid == 0x0D5A) return TRUE; /* Simucube 1 */
+    return FALSE;
+}
+
+BOOL is_fanatec_pedals(WORD vid, WORD pid)
+{
+    if (vid != 0x0EB7) return FALSE;
+    if (pid == 0x183B) return TRUE; /* Fanatec ClubSport Pedals v3 */
+    if (pid == 0x1839) return TRUE; /* Fanatec ClubSport Pedals v1/v2 */
+    return FALSE;
+}
+
 struct mouse_device
 {
     struct unix_device unix_device;


### PR DESCRIPTION
Simucube FFB wheels have an additional function to control the maximum steering angle through vendor hid reports. Additionally, the devices are HID PID compliant and take full advantage of Wine 7's hidraw backend, which provides FFB through the HID PID implementation.
Fanatec ClubSport pedals have rumble motors on brake and throttle, which can be controlled via the Fanatec SDK (also using vendor hid reports).
Various apps/games use these functionalities and expect them to be available for these devices.

Fixes Raceroom Racing Experience crashing in hidapi.dll (provided by game) on Proton 7/Proton Experimental 7 when trying to load a racing session.