### PR TITLE
winevulkan: Use direct calls for vkGetDescriptorEXT.

### DIFF
--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -151,6 +151,7 @@ ALLOWED_X_EXTENSIONS = [
 DIRECT_CALL_FUNCTIONS = [
     "vkCreateDevice",
     "vkEnumerateInstanceVersion",
+    "vkGetDescriptorEXT",
     "vkUpdateDescriptorSets",
     "vkUpdateDescriptorSetWithTemplate",
 # These functions involving shader compilation might require large stack


### PR DESCRIPTION
As performance sensitive as descriptor updates.