### PR TITLE
winex11.drv: Revert workaround for mutter issue #676, fixing issue #2438

### DIFF
--- a/dlls/winex11.drv/event.c
+++ b/dlls/winex11.drv/event.c
@@ -1525,19 +1525,6 @@ static BOOL X11DRV_PropertyNotify( HWND hwnd, XEvent *xev )
         XFree(name);
     }
 
-    if (event->atom == x11drv_atom(_NET_WM_BYPASS_COMPOSITOR))
-    {
-        struct x11drv_win_data *data = get_win_data( hwnd );
-        if (!data) return TRUE;
-
-        /* workaround for mutter gitlab bug #676, changing decorations of a
-         * fullscreen and unredirected window freezes the compositing.
-         */
-        if (wm_is_mutter( data->display )) set_wm_hints( data );
-
-        release_win_data( data );
-    }
-
     if (event->atom == x11drv_atom(WM_STATE)) handle_wm_state_notify( hwnd, event, TRUE );
     else if (event->atom == x11drv_atom(_NET_WM_STATE)) handle__net_wm_state_notify( hwnd, event );
     return TRUE;

--- a/dlls/winex11.drv/window.c
+++ b/dlls/winex11.drv/window.c
@@ -874,33 +874,6 @@ static void set_mwm_hints( struct x11drv_win_data *data, DWORD style, DWORD ex_s
     MwmHints mwm_hints;
     int enable_mutter_workaround, mapped;
 
-    /* workaround for mutter gitlab bug #676, changing decorations of a
-     * fullscreen and unredirected window freezes the compositing.
-     * The window style will be updated again once the window has returned
-     * from fullscreen.
-     */
-    if (wm_is_mutter(data->display) && (data->net_wm_state & (1 << NET_WM_STATE_FULLSCREEN)))
-    {
-        Atom type;
-        int format;
-        unsigned long *property, net_wm_bypass_compositor = 0, count, remaining;
-
-        if (XGetWindowProperty( data->display, data->whole_window, x11drv_atom(_NET_WM_BYPASS_COMPOSITOR), 0,
-                                1, False, XA_CARDINAL, &type, &format, &count, &remaining,
-                                (unsigned char **)&property ) == Success &&
-            property)
-        {
-            net_wm_bypass_compositor = *property;
-            XFree(property);
-        }
-
-        if (net_wm_bypass_compositor)
-        {
-            TRACE("workaround mutter bug, ignoring decorations while compositor is bypassed\n");
-            return;
-        }
-    }
-
     if (data->hwnd == GetDesktopWindow())
     {
         if (is_desktop_fullscreen()) mwm_hints.decorations = 0;


### PR DESCRIPTION
The workaround for mutter issue #676 prevents unredirected fullscreen windows from updating their decorations on mutter, breaking minimize for these windows on mutter 43 (mutter issue #2438). Although #676 remains open, the bug was fixed several years ago, and the test program attached to that issue behaves correctly on mutter 3.30 and up. As such, this hack can be safely removed, which will resolve issue #2438.

Additionally, mutter issue #306 has been fixed since mutter 3.28 and the workaround for it should also now be removed, as per its comment.

https://gitlab.gnome.org/GNOME/mutter/-/issues/2438