### PR TITLE
Revert "HACK: proton: ntdll,server: Never use CLOCK_MONOTONIC_RAW"

### DIFF
--- a/dlls/ntdll/unix/sync.c
+++ b/dlls/ntdll/unix/sync.c
@@ -92,7 +92,7 @@ static inline ULONGLONG monotonic_counter(void)
     return mach_absolute_time() * timebase.numer / timebase.denom / 100;
 #elif defined(HAVE_CLOCK_GETTIME)
     struct timespec ts;
-#if 0
+#ifdef CLOCK_MONOTONIC_RAW
     if (!clock_gettime( CLOCK_MONOTONIC_RAW, &ts ))
         return ts.tv_sec * (ULONGLONG)TICKSPERSEC + ts.tv_nsec / 100;
 #endif

--- a/server/request.c
+++ b/server/request.c
@@ -533,7 +533,7 @@ timeout_t monotonic_counter(void)
     return mach_absolute_time() * timebase.numer / timebase.denom / 100;
 #elif defined(HAVE_CLOCK_GETTIME)
     struct timespec ts;
-#if 0
+#ifdef CLOCK_MONOTONIC_RAW
     if (!clock_gettime( CLOCK_MONOTONIC_RAW, &ts ))
         return (timeout_t)ts.tv_sec * TICKS_PER_SEC + ts.tv_nsec / 100;
 #endif


### PR DESCRIPTION
This reverts commit aba1a41c5c5d430b40466d4f347aad47c5087663.

Per [1], the performance disparity has been fixed in Linux 5.3.

The hack also made vkGetCalibratedTimestampsEXT calibrate to the wrong clock, since the code to choose the time domain was designed to mirror upstream Wine behavior. A possible fix is to mirror the hack over to vkGetCalibratedTimestampsEXT, however since Linux 5.3 has been around for a while, removing the hack seems to be the better option.

[1] https://lore.kernel.org/linux-arm-kernel/20190621095252.32307-1-vincenzo.frascino@arm.com/