### PR TITLE
winevulkan: Enable VK_EXT_hdr_metadata

### DIFF
--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -95,7 +95,6 @@ UNSUPPORTED_EXTENSIONS = [
     # Device extensions
     "VK_AMD_display_native_hdr",
     "VK_EXT_full_screen_exclusive",
-    "VK_EXT_hdr_metadata", # Needs WSI work.
     "VK_GOOGLE_display_timing",
     "VK_KHR_external_fence_win32",
     # Relates to external_semaphore and needs type conversions in bitflags.


### PR DESCRIPTION
This works fine with the new struct conversions, and is needed for HDR with native Vulkan games such as Doom Eternal and games using HDR with DXVK and VKD3D-Proton.