### PR TITLE
kernelbase: Fix Paradox Launcher for Hearts of Iron IV

### DIFF
--- a/dlls/kernelbase/process.c
+++ b/dlls/kernelbase/process.c
@@ -592,7 +592,6 @@ static const WCHAR *hack_append_command_line( const WCHAR *cmd )
     options[] =
     {
         {L"UplayWebCore.exe", L" --use-angle=gl"},
-        {L"Paradox Launcher.exe", L" --use-gl=swiftshader --in-process-gpu"},
         {L"Montaro\\nw.exe", L" --use-gl=swiftshader"},
         {L"EOSOverlayRenderer-Win64-Shipping.exe", L" --use-gl=swiftshader --in-process-gpu"},
         {L"EpicOnlineServicesUIHelper", L" --use-gl=desktop"},


### PR DESCRIPTION
Paradox Launcher displays a black screen on any version of Proton, this MR fixes this behavior by removing no longer necessary hack.