### PR TITLE
wine.inf: HACK: Disable SpeechSynthesisWrapper.dll for Pentiment.

### DIFF
--- a/loader/wine.inf.in
+++ b/loader/wine.inf.in
@@ -5948,3 +5948,4 @@ HKCU,Software\Wine\AppDefaults\SpellForce.exe\X11 Driver,"LimitNumberOfResolutio
 HKCU,Software\Wine\AppDefaults\Nickelodeon All-Star Brawl.exe\DllOverrides,"winusb",,"disabled"
 HKLM,Software\Wow6432Node\lucasarts entertainment company llc\Star Wars: Episode I Racer\v1.0,"Display Height",0x10001,480
 HKLM,Software\Wow6432Node\lucasarts entertainment company llc\Star Wars: Episode I Racer\v1.0,"Display Width",0x10001,640
+HKCU,Software\Wine\AppDefaults\Pentiment.exe\DllOverrides,"SpeechSynthesisWrapper",,"disabled"


### PR DESCRIPTION
The game crashes when utilizing it and works without it, like seen already on the Steam Deck with its specific depot.

https://steamdb.info/depot/1205522/
https://github.com/ValveSoftware/Proton/issues/6415#issuecomment-1379357568

Followup of https://github.com/ValveSoftware/Proton/pull/6479 after verifying that running the game with the suggested workaround `WINEDLLOVERRIDES=SpeechSynthesisWrapper.dll=d %command%` works fine.