### PR TITLE
Override Bloodrayne Terminal Cut 1/2 to use built in DX8-9 wrapper.

### DIFF
--- a/loader/wine.inf.in
+++ b/loader/wine.inf.in
@@ -5948,3 +5948,5 @@ HKCU,Software\Wine\AppDefaults\SpellForce.exe\X11 Driver,"LimitNumberOfResolutio
 HKCU,Software\Wine\AppDefaults\Nickelodeon All-Star Brawl.exe\DllOverrides,"winusb",,"disabled"
 HKLM,Software\Wow6432Node\lucasarts entertainment company llc\Star Wars: Episode I Racer\v1.0,"Display Height",0x10001,480
 HKLM,Software\Wow6432Node\lucasarts entertainment company llc\Star Wars: Episode I Racer\v1.0,"Display Width",0x10001,640
+HKCU,Software\Wine\AppDefaults\rayne1.exe\DllOverrides,"d3d8",,"native"
+HKCU,Software\Wine\AppDefaults\rayne2.exe\DllOverrides,"d3d8",,"native"


### PR DESCRIPTION
Proton doesn't use the games wrapper by default, causing WineD3D to be used over DXVK, which causes massive slowdown and a few misc bugs.