### PR TITLE
Fix handling for ALG_ID_ECDH_P384

### DIFF
--- a/dlls/bcrypt/bcrypt_main.c
+++ b/dlls/bcrypt/bcrypt_main.c
@@ -1701,6 +1701,7 @@ NTSTATUS WINAPI BCryptGenerateKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_H
     case ALG_ID_ECDSA_P256:
         size = sizeof(BCRYPT_ECCKEY_BLOB) + 2 * 256 / 8;
         break;
+    case ALG_ID_ECDH_P384:
     case ALG_ID_ECDSA_P384:
         size = sizeof(BCRYPT_ECCKEY_BLOB) + 2 * 384 / 8;
         break;


### PR DESCRIPTION
This fixes a missing case statement for handling ALG_ID_ECDH_P384.

This has at least fixed Anno 1800 multiplayer session negotiation, which did not work at all with Proton 7.0-6 (the one provided in Steam), but works like a charm after this patch has been applied to it.

The other PR (#173) adds extra code that is not required and already is present at line 1406 in wine/dlls/bcrypt/bcrypt_main.c