### PR TITLE
wine.inf: HACK: Disable SpeechSynthWrapper.dll for Grounded.

### DIFF
--- a/loader/wine.inf.in
+++ b/loader/wine.inf.in
@@ -2871,3 +2871,5 @@ HKCU,Software\Wine\AppDefaults\DarkSoulsIII.exe\X11 Driver,"LimitNumberOfResolut
 HKCU,Software\Wine\AppDefaults\sekiro.exe\X11 Driver,"LimitNumberOfResolutions",0x2,"32"
 HKCU,Software\Wine\AppDefaults\NieRAutomata.exe\X11 Driver,"LimitNumberOfResolutions",0x2,"32"
 HKCU,Software\Wine\AppDefaults\SpellForce.exe\X11 Driver,"LimitNumberOfResolutions",0x2,"16"
+;;Other app-specific overrides
+HKCU,Software\Wine\AppDefaults\Grounded.exe\DllOverrides,"SpeechSynthWrapper",,"disabled"


### PR DESCRIPTION
Infinite loading screen when utilizing it and works without it, like seen already on the Steam Deck with its specific depot.

https://steamdb.info/depot/962134/
https://github.com/ValveSoftware/Proton/issues/4102#issuecomment-1262414567

Note: I don't personally own the game yet so I couldn't actually test this (Got the game executable name from the depot viewing https://steamdb.info/depot/962131/ please verify before merging). For reference, a quite similiar workaround has been implemented for Pentiment with https://github.com/ValveSoftware/wine/commit/915267f77ba2d68e3f5bea9a6bb158df067778cf where the dll file is named a bit different.

Grounded: `SpeechSynthWrapper.dll` - https://steamdb.info/depot/962134/
Pentiment: `SpeechSynthesisWrapper.dll` - https://steamdb.info/depot/1205522/