### PR TITLE
wine.inf: Set msvcp140_atomic_wait to native,builtin.

### DIFF
--- a/loader/wine.inf.in
+++ b/loader/wine.inf.in
@@ -2828,6 +2828,7 @@ HKCU,Software\Wine\DllOverrides,"api-ms-win-crt-time-l1-1-0",0x2,"native,builtin
 HKCU,Software\Wine\DllOverrides,"atl140",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"concrt140",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"msvcp140",0x2,"native,builtin"
+HKCU,Software\Wine\DllOverrides,"msvcp140_atomic_wait",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"msvcr140",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"ucrtbase",0x2,"native,builtin"
 HKCU,Software\Wine\DllOverrides,"vcomp140",0x2,"native,builtin"


### PR DESCRIPTION
Regression from proton 6.3 (which didn't have msvcp140_atomic_wait). ~~Without this patch, there is a mismatch between native msvcp and built-in msvcp causing an unimplemented function crash/exception.~~ 
some games can call unimplemented methods in the built-in version of the dll, so set it to native (like all the others)

