### PR TITLE
atiadlxx: Add stub for ADL2_Main_Control_Destroy. 

### DIFF
--- a/dlls/atiadlxx/atiadlxx.spec
+++ b/dlls/atiadlxx/atiadlxx.spec
@@ -452,7 +452,7 @@
 @ stub ADL2_MMD_Video_Caps
 @ stub ADL2_Main_ControlX2_Create
 @ stdcall ADL2_Main_Control_Create(ptr long ptr)
-@ stub ADL2_Main_Control_Destroy
+@ stdcall ADL2_Main_Control_Destroy(ptr)
 @ stub ADL2_Main_Control_GetProcAddress
 @ stub ADL2_Main_Control_IsFunctionValid
 @ stub ADL2_Main_Control_Refresh

--- a/dlls/atiadlxx/atiadlxx_main.c
+++ b/dlls/atiadlxx/atiadlxx_main.c
@@ -190,6 +190,13 @@ int WINAPI ADL2_Main_Control_Create(ADL_MAIN_MALLOC_CALLBACK cb, int arg, ADL_CO
     return ADL_OK;
 }
 
+int WINAPI ADL2_Main_Control_Destroy(ADL_CONTEXT_HANDLE handle)
+{
+    FIXME("handle %p stub!\n")
+
+    return ADL_OK;
+}
+
 int WINAPI ADL_Main_Control_Create(ADL_MAIN_MALLOC_CALLBACK cb, int arg)
 {
     FIXME("cb %p, arg %d stub!\n", cb, arg);


### PR DESCRIPTION
This removes the outdated driver prompt in Rainbow 6 Extraction. The game still crashes due to another issue (probably winevulkan not supporting pAllocator)

edit: you need to manually add the dll override, until someone actually gets it working