### PR TITLE
Support VKB Gladiator NXT EVO and Virpil Constellation

### DIFF
--- a/dlls/winebus.sys/unix_private.h
+++ b/dlls/winebus.sys/unix_private.h
@@ -271,6 +271,6 @@ BOOL is_wine_blacklisted(WORD vid, WORD pid) DECLSPEC_HIDDEN;
 BOOL is_dualshock4_gamepad(WORD vid, WORD pid) DECLSPEC_HIDDEN;
 BOOL is_dualsense_gamepad(WORD vid, WORD pid) DECLSPEC_HIDDEN;
 BOOL is_logitech_g920(WORD vid, WORD pid) DECLSPEC_HIDDEN;
-BOOL is_hidraw_enabled(WORD vid, WORD pid) DECLSPEC_HIDDEN;
+BOOL is_hidraw_enabled(WORD vid, WORD pid, INT axes, INT buttons) DECLSPEC_HIDDEN;
 
 #endif /* __WINEBUS_UNIX_PRIVATE_H */

--- a/dlls/winebus.sys/unixlib.c
+++ b/dlls/winebus.sys/unixlib.c
@@ -118,6 +118,18 @@ static BOOL is_vkb_controller(WORD vid, WORD pid, INT buttons)
     return FALSE;
 }
 
+static BOOL is_virpil_controller(WORD vid, WORD pid, INT buttons)
+{
+    if (vid != 0x3344) return FALSE;
+
+    /* comes with 31 buttons in the default configuration, or 128 max */
+    if ((buttons == 31) || (buttons == 128)) return TRUE;
+
+    /* if customized, arbitrary amount of buttons may be shown, decide by PID */
+    if (pid == 0x412f) return TRUE; /* Virpil Constellation ALPHA-R */
+    return FALSE;
+}
+
 BOOL is_hidraw_enabled(WORD vid, WORD pid, INT axes, INT buttons)
 {
     const char *enabled = getenv("PROTON_ENABLE_HIDRAW");
@@ -129,6 +141,7 @@ BOOL is_hidraw_enabled(WORD vid, WORD pid, INT axes, INT buttons)
     if (is_simucube_wheel(vid, pid)) return TRUE;
     if (is_fanatec_pedals(vid, pid)) return TRUE;
     if (is_vkb_controller(vid, pid, buttons)) return TRUE;
+    if (is_virpil_controller(vid, pid, buttons)) return TRUE;
 
     sprintf(needle, "0x%04x/0x%04x", vid, pid);
     if (enabled) return strcasestr(enabled, needle) != NULL;

--- a/dlls/winebus.sys/unixlib.c
+++ b/dlls/winebus.sys/unixlib.c
@@ -105,7 +105,7 @@ static BOOL is_fanatec_pedals(WORD vid, WORD pid)
     return FALSE;
 }
 
-BOOL is_hidraw_enabled(WORD vid, WORD pid)
+BOOL is_hidraw_enabled(WORD vid, WORD pid, INT axes, INT buttons)
 {
     const char *enabled = getenv("PROTON_ENABLE_HIDRAW");
     char needle[16];

--- a/dlls/winebus.sys/unixlib.c
+++ b/dlls/winebus.sys/unixlib.c
@@ -105,6 +105,19 @@ static BOOL is_fanatec_pedals(WORD vid, WORD pid)
     return FALSE;
 }
 
+static BOOL is_vkb_controller(WORD vid, WORD pid, INT buttons)
+{
+    if (vid != 0x231D) return FALSE;
+
+    /* comes with 128 buttons in the default configuration */
+    if (buttons == 128) return TRUE;
+
+    /* if customized, less than 128 buttons may be shown, decide by PID */
+    if (pid == 0x0200) return TRUE; /* VKBsim Gladiator EVO Right Grip */
+    if (pid == 0x0201) return TRUE; /* VKBsim Gladiator EVO Left Grip */
+    return FALSE;
+}
+
 BOOL is_hidraw_enabled(WORD vid, WORD pid, INT axes, INT buttons)
 {
     const char *enabled = getenv("PROTON_ENABLE_HIDRAW");
@@ -115,6 +128,7 @@ BOOL is_hidraw_enabled(WORD vid, WORD pid, INT axes, INT buttons)
     if (is_thrustmaster_hotas(vid, pid)) return TRUE;
     if (is_simucube_wheel(vid, pid)) return TRUE;
     if (is_fanatec_pedals(vid, pid)) return TRUE;
+    if (is_vkb_controller(vid, pid, buttons)) return TRUE;
 
     sprintf(needle, "0x%04x/0x%04x", vid, pid);
     if (enabled) return strcasestr(enabled, needle) != NULL;

--- a/include/msvcrt/corecrt.h
+++ b/include/msvcrt/corecrt.h
@@ -82,7 +82,7 @@
 #define __has_attribute(x) 0
 #endif
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#ifndef _MSC_VER
 # undef __stdcall
 # ifdef __i386__
 #  ifdef __GNUC__
@@ -100,13 +100,16 @@
 #  else
 #   define __stdcall __attribute__((ms_abi))
 #  endif
-# elif defined(__arm__) && defined (__GNUC__) && !defined(__SOFTFP__) && !defined(__CYGWIN__)
+# elif defined(__arm__) && defined (__GNUC__) && !defined(__SOFTFP__) && !defined(__MINGW32__) && !defined(__CYGWIN__)
 #   define __stdcall __attribute__((pcs("aapcs-vfp")))
 # elif defined(__aarch64__) && defined (__GNUC__) && __has_attribute(ms_abi)
 #  define __stdcall __attribute__((ms_abi))
 # else  /* __i386__ */
 #  define __stdcall
 # endif  /* __i386__ */
+#endif /* __stdcall */
+
+#ifndef _MSC_VER
 # undef __cdecl
 # if defined(__i386__) && defined(__GNUC__)
 #  if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2)) || defined(__APPLE__)
@@ -117,7 +120,7 @@
 # else
 #  define __cdecl __stdcall
 # endif
-#endif  /* _MSC_VER || __MINGW32__ */
+#endif
 
 #if (defined(__x86_64__) || (defined(__aarch64__) && __has_attribute(ms_abi))) && defined (__GNUC__)
 # include <stdarg.h>

--- a/include/windef.h
+++ b/include/windef.h
@@ -54,7 +54,7 @@ extern "C" {
 # endif
 #endif
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#ifndef _MSC_VER
 # undef __stdcall
 # ifdef __i386__
 #  ifdef __GNUC__
@@ -72,13 +72,16 @@ extern "C" {
 #  else
 #   define __stdcall __attribute__((ms_abi))
 #  endif
-# elif defined(__arm__) && defined (__GNUC__) && !defined(__SOFTFP__) && !defined(__CYGWIN__)
+# elif defined(__arm__) && defined (__GNUC__) && !defined(__SOFTFP__) && !defined(__MINGW32__) && !defined(__CYGWIN__)
 #   define __stdcall __attribute__((pcs("aapcs-vfp")))
 # elif defined(__aarch64__) && defined (__GNUC__) && __has_attribute(ms_abi)
 #  define __stdcall __attribute__((ms_abi))
 # else  /* __i386__ */
 #  define __stdcall
 # endif  /* __i386__ */
+#endif /* __stdcall */
+
+#ifndef _MSC_VER
 # undef __cdecl
 # if defined(__i386__) && defined(__GNUC__)
 #  if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2)) || defined(__APPLE__)
@@ -89,13 +92,15 @@ extern "C" {
 # else
 #  define __cdecl __stdcall
 # endif
-# ifndef __fastcall
-#  define __fastcall __stdcall
-# endif
-# ifndef __thiscall
-#  define __thiscall __stdcall
-# endif
-#endif  /* _MSC_VER || __MINGW32__ */
+#endif
+
+#if !defined(_MSC_VER) && !defined(__fastcall)
+# define __fastcall __stdcall
+#endif
+
+#if (!defined(_MSC_VER) || !defined(__clang__)) && !defined(__thiscall)
+# define __thiscall __stdcall
+#endif
 
 #ifndef __ms_va_list
 # if (defined(__x86_64__) || (defined(__aarch64__) && __has_attribute(ms_abi))) && defined (__GNUC__)


### PR DESCRIPTION
These devices ship with 128 buttons by default. For game compatibility, the VKB Windows app can be used to change the HID descriptor to show only 32 buttons and have up to 4 virtual devices instead. These devices can also show up as a mouse or keyboard and send proper HID events for that configuration - not tested with this commit.

The Linux input layer gets really confused by these devices as the HID descriptor spans multiple ranges of different device type event codes. Hopefully, winebus.sys hidraw mode can work around this. Also needs udev rules to enable hidraw access.

**Device info maybe relevant for implementation:**
- has a programmable mini computer (32-bit ARM) which generates USB HID reports
- can be programmed to act as a mouse or keyboard, too
- consists of a base module and module extensions which are mountable grips
- can generate events for up to 128 buttons (through various shift and macro operations)
- can generate events for up to 16 axes (twice the amount of ordinary joystick devices)
- can generate events for up to 4 hats (8-way, usually, joysticks support just one 4-way hat)
- can be split into up to four virtual devices which split 128 buttons into 32 buttons each for better compatibility

**Known limits:**
- Elite Dangerous: 32 buttons
- Star Citizen: 50 buttons
- some other games: 64 buttons

**Todo:**
- [x] Figure out why [Elite Dangerous](https://github.com/ValveSoftware/Proton/issues/150) still sees a single gamepad -> needs registry cleanup, see below
- [ ] Figure out how to clean the registry from broken xinput driver links
- [x] Test if other games properly see the joysticks
- [ ] Ask if we should mention somewhere to split the HID descriptor into 4 virtual devices

Without this patch, it's currently the same as running with `PROTON_ENABLE_HIDRAW=0x23D1/0x0200,0x23D1/0x0201`.

## Notes

**There's a hint about games seeing a gamepad with other HOTAS, too:**
- https://github.com/ValveSoftware/Proton/issues/6839 - but SDL should be bypassed with hidraw
- https://www.reddit.com/user/xatrekak/comments/12hnz0d/fixing_vkb_and_virpil_hotas_running_on_linux/
- `0084:trace:hid:udev_add_device hidraw "/dev/hidraw6": deferring {vid 231d, pid 0200, version 2122, input 0, uid 00000000, is_gamepad 0} to a different backend`
- maybe needs auto-correction of registry after switching to hidraw if the device was detected as xinput before?

**The Windows software supports creating a registry patch which adds these entries:**
```ini
Windows Registry Editor Version 5.00

[-HKEY_CURRENT_USER\SYSTEM\CurrentControlSet\Control\MediaProperties\PrivateProperties\Joystick\OEM\Vid_231D&Pid_0200]
[-HKEY_CURRENT_USER\System\CurrentControlSet\Control\MediaProperties\PrivateProperties\DirectInput\Vid_231D&Pid_0200]
[-HKEY_CURRENT_USER\System\CurrentControlSet\Control\MediaResources\Joystick\DINPUT.DLL\JoystickSettings\Vid_231D&Pid_0200]
[-HKEY_CURRENT_USER\System\CurrentControlSet\Control\MediaResources\Joystick\DINPUT.DLL\CurrentJoystickSettings]
[-HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\USB\Vid_231D&Pid_0200]
[-HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\HID\Vid_231D&Pid_0200]
[-HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Enum\USB\Vid_231D&Pid_0200]
[-HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Enum\HID\Vid_231D&Pid_0200]
```
But this looks like just creating empty nodes. **Edit:** It seems that this actually deletes contents from the nodes.

**Wine adds registry entries linking the device to winebus driver but also to xinput:**
- example: `System\\CurrentControlSet\\Enum\\WINEBUS\\VID_231D&PID_0201` (vid/pid exists lower and upper case in the registry)
- removing those references from `system.reg` properly links the joystick to the HID driver next time the game starts