### PR TITLE
winex11.drv: Ensure initialized thread data in X11DRV_get_ic.

### DIFF
--- a/dlls/winex11.drv/xim.c
+++ b/dlls/winex11.drv/xim.c
@@ -501,7 +501,7 @@ XIC X11DRV_get_ic( HWND hwnd )
     XIC ret;
 
     if (!(data = get_win_data( hwnd ))) return 0;
-    x11drv_thread_data()->last_xic_hwnd = hwnd;
+    x11drv_init_thread_data()->last_xic_hwnd = hwnd;
     if (!(ret = data->xic) && (xim = x11drv_thread_data()->xim))
         ret = data->xic = xic_create( xim, hwnd, data->whole_window );
     release_win_data( data );


### PR DESCRIPTION
Fixes a crash in world of warships

bisected to [0b74f0b5f55b02df23160fcaf64226e1a8658309](https://github.com/ValveSoftware/wine/commit/0b74f0b5f55b02df23160fcaf64226e1a8658309) (by GloriousEggroll)