### PR TITLE
winex11: fix missing null check in glxdrv_wglSwapBuffers.

### DIFF
--- a/dlls/winex11.drv/opengl.c
+++ b/dlls/winex11.drv/opengl.c
@@ -4926,7 +4926,7 @@ static BOOL glxdrv_wglSwapBuffers( HDC hdc )
     update_window_surface( gl, hwnd );
     release_gl_drawable( gl );
 
-    if (escape.drawable) NtGdiExtEscape( ctx->hdc, NULL, 0, X11DRV_ESCAPE, sizeof(escape), (LPSTR)&escape, 0, NULL );
+    if (escape.drawable && ctx) NtGdiExtEscape( ctx->hdc, NULL, 0, X11DRV_ESCAPE, sizeof(escape), (LPSTR)&escape, 0, NULL );
     return TRUE;
 }
 


### PR DESCRIPTION
fixes an exception in Black desert online's launcher. launcher is still black tho :(