### PR TITLE
ntdll: Don't leak objattr allocation in NtCreateSemaphore.

### DIFF
--- a/dlls/ntdll/unix/sync.c
+++ b/dlls/ntdll/unix/sync.c
@@ -273,13 +273,14 @@ NTSTATUS WINAPI NtCreateSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJ
 
     *handle = 0;
     if (max <= 0 || initial < 0 || initial > max) return STATUS_INVALID_PARAMETER;
-    if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
 
     if (do_fsync())
         return fsync_create_semaphore( handle, access, attr, initial, max );
 
     if (do_esync())
         return esync_create_semaphore( handle, access, attr, initial, max );
+
+    if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
 
     SERVER_START_REQ( create_semaphore )
     {


### PR DESCRIPTION
fsync/esync_create_semaphore allocates objattr on their own, and objattr allocated in NtCreateSemaphore was getting leaked.

Like NtCreateEvent, move the objattr allocation after fsync/esync early return to avoid double allocation.