### PR TITLE
quartz: HACK: Return success from SetTimeFormat for SWAT 3.

### DIFF
--- a/dlls/quartz/filtergraph.c
+++ b/dlls/quartz/filtergraph.c
@@ -2223,6 +2223,7 @@ static HRESULT WINAPI MediaSeeking_IsUsingTimeFormat(IMediaSeeking *iface, const
 static HRESULT WINAPI MediaSeeking_SetTimeFormat(IMediaSeeking *iface, const GUID *pFormat)
 {
     struct filter_graph *This = impl_from_IMediaSeeking(iface);
+    const char *sgi;
 
     if (!pFormat)
         return E_POINTER;
@@ -2232,6 +2233,11 @@ static HRESULT WINAPI MediaSeeking_SetTimeFormat(IMediaSeeking *iface, const GUI
     if (!IsEqualGUID(&TIME_FORMAT_MEDIA_TIME, pFormat))
     {
         FIXME("Unhandled time format %s\n", debugstr_guid(pFormat));
+
+        /* SWAT 3 video fix */
+        if ((sgi = getenv("SteamGameId")) && !strcmp(sgi, "560370"))
+            return S_OK;
+
         return E_INVALIDARG;
     }
 


### PR DESCRIPTION
SWAT 3 (560370) crashes on start when the intro video requests the unimplemented TIME_FORMAT_FRAME format.  The game will however launch and play videos using the default time format as long as SetTimeFormat returns successfully.

It was possible to start the game using the "-nointro" argument but it would crash again when the single player campaign is loaded.

Note: Only tested using the GOG release of the game.