### PR TITLE
Add call tools/make_specfiles to autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 tools/make_requests
+tools/make_specfiles
 dlls/winevulkan/make_vulkan -x vk.xml
 autoreconf -ifv
 rm -rf autom4te.cache


### PR DESCRIPTION
If you don't call tools/make_specfiles then build will fail saying it's missing ntsyscalls.h. 

This confused me and a few others (https://github.com/ValveSoftware/wine/issues/221, https://github.com/ValveSoftware/wine/issues/238). Adding the call to autogen.sh to avoid this issue in the future