### PR TITLE
mmdevapi: Support getting IAudioClockAdjustment interface.

### DIFF
--- a/dlls/mmdevapi/client.c
+++ b/dlls/mmdevapi/client.c
@@ -880,6 +880,9 @@ static HRESULT WINAPI client_GetService(IAudioClient3 *iface, REFIID riid, void 
     } else if (IsEqualIID(riid, &IID_IAudioClock)) {
         IAudioClock_AddRef(&This->IAudioClock_iface);
         *ppv = &This->IAudioClock_iface;
+    } else if (IsEqualIID(riid, &IID_IAudioClockAdjustment)) {
+        IAudioClockAdjustment_AddRef(&This->IAudioClockAdjustment_iface);
+        *ppv = &This->IAudioClockAdjustment_iface;
     } else if (IsEqualIID(riid, &IID_IAudioStreamVolume)) {
         IAudioStreamVolume_AddRef(&This->IAudioStreamVolume_iface);
         *ppv = &This->IAudioStreamVolume_iface;


### PR DESCRIPTION
Allows ghostbusters the video game remastered (ID 1449280) to play the 4K high definition videos through mfplat. since mfplat is finally able to handle this game :)