### PR TITLE
kernelbase: Fix return on failed VirtualQueryEx

### DIFF
--- a/dlls/kernelbase/memory.c
+++ b/dlls/kernelbase/memory.c
@@ -613,7 +613,7 @@ BOOL WINAPI DECLSPEC_HOTPATCH WriteProcessMemory( HANDLE process, void *addr, co
     if (!VirtualQueryEx( process, addr, &info, sizeof(info) ))
     {
         close_cross_process_connection( list );
-        return FALSE;
+        return set_ntstatus( NtWriteVirtualMemory( process, addr, buffer, size, bytes_written ));
     }
 
     switch (info.Protect)


### PR DESCRIPTION
Issues mentioned in [#8208](https://github.com/ValveSoftware/Proton/issues/8208);

Returning specific booleans such as `FALSE`, `TRUE` causes `WriteProcessMemory` to break, noticeably with Dark and Darker's anti-cheat "TavernWorker".

This patch returns the `NTSTATUS` of `NtWriteVirtualMemory` as solely handled previously, however now only in cases where `VirtualQueryEx` responds with an error.