### PR TITLE
fix: Implicit narrowing conversion in compound assignment

### DIFF
--- a/dlls/wineandroid.drv/WineActivity.java
+++ b/dlls/wineandroid.drv/WineActivity.java
@@ -593,7 +593,7 @@ public class WineActivity extends Activity
         }
 
         /* wrapper for layout() making sure that the view is not empty */
-        public void set_layout( int left, int top, int right, int bottom )
+        public void set_layout( float left, float top, float right, float bottom )
         {
             left   *= win.scale;
             top    *= win.scale;
@@ -601,7 +601,7 @@ public class WineActivity extends Activity
             bottom *= win.scale;
             if (right <= left + 1) right = left + 2;
             if (bottom <= top + 1) bottom = top + 2;
-            layout( left, top, right, bottom );
+            layout( (int)left, (int)top, (int)right, (int)bottom );
         }
 
         @Override


### PR DESCRIPTION
## Patched 🎟️ 
---
https://github.com/ValveSoftware/wine/blob/015230dc0f78a543032dea0907f6c97304b25ca3/dlls/wineandroid.drv/WineActivity.java#L598-L598


Compound assignment statements of the form `x += y` or `x *= y` perform an implicit narrowing conversion if the type of `x` is narrower than the type of `y`. `x += y` is equivalent to `x = (T)(x + y)`, where `T` is the type of `x`. This can result in information loss and numeric errors such as overflows.

## POC
If `x` is of type `short` and `y` is of type `int`, the expression `x + y` is of type `int`. However, the expression `x += y` is equivalent to `x = (short) (x + y)`. The expression `x + y` is cast to the type of the left-hand side of the assignment: `short`, possibly leading to information loss.

[CWE-190](https://cwe.mitre.org/data/definitions/190.html)
[CWE-192](https://cwe.mitre.org/data/definitions/192.html)
[CWE-197](https://cwe.mitre.org/data/definitions/197.html)
[CWE-681](https://cwe.mitre.org/data/definitions/681.html)