### PR TITLE
kernelbase: Add WerRegisterCustomMetadata stub.

### DIFF
--- a/dlls/kernel32/kernel32.spec
+++ b/dlls/kernel32/kernel32.spec
@@ -1624,10 +1624,12 @@
 @ stdcall WakeAllConditionVariable(ptr) NTDLL.RtlWakeAllConditionVariable
 @ stdcall WakeConditionVariable(ptr) NTDLL.RtlWakeConditionVariable
 @ stdcall -import WerGetFlags(ptr ptr)
+@ stdcall -import WerRegisterCustomMetadata(wstr wstr)
 @ stdcall -import WerRegisterFile(wstr long long)
 @ stdcall -import WerRegisterMemoryBlock(ptr long)
 @ stdcall -import WerRegisterRuntimeExceptionModule(wstr ptr)
 @ stdcall -import WerSetFlags(long)
+@ stdcall -import WerUnregisterCustomMetadata(wstr)
 @ stdcall -import WerUnregisterFile(wstr)
 @ stdcall -import WerUnregisterMemoryBlock(ptr)
 @ stdcall -import WerUnregisterRuntimeExceptionModule(wstr ptr)

--- a/dlls/kernelbase/debug.c
+++ b/dlls/kernelbase/debug.c
@@ -756,6 +756,16 @@ HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerGetFlags( HANDLE process, DWORD *flags
 
 
 /***********************************************************************
+ *         WerRegisterCustomMetadata  (kernelbase.@)
+ */
+HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerRegisterCustomMetadata( const WCHAR *key, const WCHAR *value )
+{
+    FIXME( "(%s, %s) stub\n", debugstr_w(key), debugstr_w(value) );
+    return S_OK;
+}
+
+
+/***********************************************************************
  *         WerRegisterFile   (kernelbase.@)
  */
 HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerRegisterFile( const WCHAR *file, WER_REGISTER_FILE_TYPE type,
@@ -792,6 +802,16 @@ HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerRegisterRuntimeExceptionModule( const 
 HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerSetFlags( DWORD flags )
 {
     FIXME("(%ld) stub\n", flags);
+    return S_OK;
+}
+
+
+/***********************************************************************
+ *         WerUnregisterCustomMetadata  (kernelbase.@)
+ */
+HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerUnregisterCustomMetadata( const WCHAR *key )
+{
+    FIXME( "(%s) stub\n", debugstr_w(key));
     return S_OK;
 }
 

--- a/dlls/kernelbase/kernelbase.spec
+++ b/dlls/kernelbase/kernelbase.spec
@@ -1750,10 +1750,12 @@
 @ stdcall WakeByAddressSingle(ptr) ntdll.RtlWakeAddressSingle
 @ stdcall WakeConditionVariable(ptr) ntdll.RtlWakeConditionVariable
 @ stdcall WerGetFlags(ptr ptr)
+@ stdcall WerRegisterCustomMetadata(wstr wstr)
 @ stdcall WerRegisterFile(wstr long long)
 @ stdcall WerRegisterMemoryBlock(ptr long)
 @ stdcall WerRegisterRuntimeExceptionModule(wstr ptr)
 @ stdcall WerSetFlags(long)
+@ stdcall WerUnregisterCustomMetadata(wstr)
 @ stdcall WerUnregisterFile(wstr)
 @ stdcall WerUnregisterMemoryBlock(ptr)
 @ stdcall WerUnregisterRuntimeExceptionModule(wstr ptr)

--- a/include/werapi.h
+++ b/include/werapi.h
@@ -175,6 +175,7 @@ typedef struct _WER_EXCEPTION_INFORMATION
 
 HRESULT WINAPI WerAddExcludedApplication(PCWSTR, BOOL);
 HRESULT WINAPI WerGetFlags(HANDLE process, DWORD *flags);
+HRESULT WINAPI WerRegisterCustomMetadata(PCWSTR key, PCWSTR value);
 HRESULT WINAPI WerRegisterFile(PCWSTR file, WER_REGISTER_FILE_TYPE regfiletype, DWORD flags);
 HRESULT WINAPI WerRegisterMemoryBlock(void *block, DWORD size);
 HRESULT WINAPI WerRegisterRuntimeExceptionModule(PCWSTR callbackdll, void *context);
@@ -186,6 +187,7 @@ HRESULT WINAPI WerReportSetParameter(HREPORT, DWORD, PCWSTR, PCWSTR);
 HRESULT WINAPI WerReportSetUIOption(HREPORT, WER_REPORT_UI, PCWSTR);
 HRESULT WINAPI WerReportSubmit(HREPORT, WER_CONSENT, DWORD, PWER_SUBMIT_RESULT);
 HRESULT WINAPI WerSetFlags(DWORD flags);
+HRESULT WINAPI WerUnregisterCustomMetadata(PCWSTR key);
 HRESULT WINAPI WerUnregisterFile(PCWSTR file);
 HRESULT WINAPI WerUnregisterMemoryBlock(void *block);
 HRESULT WINAPI WerUnregisterRuntimeExceptionModule(PCWSTR callbackdll, void *context);


### PR DESCRIPTION
Microsoft Flight Simulator 2024 needs this since SU1.

Hope this is the right way to do it. Cherry-picked from official wine-mirror.
https://github.com/wine-mirror/wine/commit/9329843456750372e771d4967190374554d20523