### PR TITLE
rsaenh: Ignore reserved field in import_key.

### DIFF
--- a/dlls/rsaenh/rsaenh.c
+++ b/dlls/rsaenh/rsaenh.c
@@ -3506,14 +3506,14 @@ static BOOL import_key(HCRYPTPROV hProv, const BYTE *pbData, DWORD dwDataLen, HC
         return FALSE;
 
     if (dwDataLen < sizeof(BLOBHEADER) || 
-        pBlobHeader->bVersion != CUR_BLOB_VERSION ||
-        pBlobHeader->reserved != 0) 
+        pBlobHeader->bVersion != CUR_BLOB_VERSION)
     {
-        TRACE("bVersion = %d, reserved = %d\n", pBlobHeader->bVersion,
-              pBlobHeader->reserved);
+        TRACE("bVersion = %d", pBlobHeader->bVersion);
         SetLastError(NTE_BAD_DATA);
         return FALSE;
     }
+    if (pBlobHeader->reserved != 0)
+        WARN("reserved != 0: %d\n", pBlobHeader->reserved);
 
     /* If this is a verify-only context, the key is not persisted regardless of
      * fStoreKey's original value.


### PR DESCRIPTION
Cherry-pick https://gitlab.winehq.org/wine/wine/-/merge_requests/7744 into Proton. This would help the
[MHServerEmu](https://github.com/Crypto137/MHServerEmu) community, so they don't have to instruct Linux/Steam Deck users to patch their game client anymore.

(I'm a bit hesitant to create a compatibility ticket for AppID 226320, since the game isn't public anymore)

RISK: Very low. This shouldn't affect any other software, since it "just" fixes a compatibility issue (API misuse) for this one specific instance.

(cherry picked from commit c3f5af8f16d6815e9254b7b532e54edcedbea9cd)
