### PR TITLE
fix Implicit narrowing conversion in compound assignment

### DIFF
--- a/dlls/wineandroid.drv/WineActivity.java
+++ b/dlls/wineandroid.drv/WineActivity.java
@@ -593,7 +593,7 @@ public class WineActivity extends Activity
         }
 
         /* wrapper for layout() making sure that the view is not empty */
-        public void set_layout( int left, int top, int right, int bottom )
+        public void set_layout( float left, float top, float right, float bottom )
         {
             left   *= win.scale;
             top    *= win.scale;
@@ -601,7 +601,7 @@ public class WineActivity extends Activity
             bottom *= win.scale;
             if (right <= left + 1) right = left + 2;
             if (bottom <= top + 1) bottom = top + 2;
-            layout( left, top, right, bottom );
+            layout( (int)left, (int)top, (int)right, (int)bottom );
         }
 
         @Override


### PR DESCRIPTION
https://github.com/ValveSoftware/wine/blob/015230dc0f78a543032dea0907f6c97304b25ca3/dlls/wineandroid.drv/WineActivity.java#L598-L598

fix the problem, need to ensure that the result of the multiplication is not implicitly cast to a narrower type. We can achieve this by changing the type of the `left`, `top`, `right`, and `bottom` variables to `float`. This way, the multiplication will be performed in floating-point arithmetic, and no information will be lost. After performing the necessary calculations, we can cast the final values to `int` before passing them to the `layout` method.

## References
J. Bloch and N. Gafter, Java Puzzlers: Traps, Pitfalls, and Corner Cases, Puzzle 9. Addison-Wesley, 2005
Java Language Specification: [Compound Assignment Operators](https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.26.2), [Narrowing Primitive Conversion](https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html#jls-5.1.3)
SEI CERT Oracle Coding Standard for Java: [NUM00-J. Detect or prevent integer overflow](https://wiki.sei.cmu.edu/confluence/display/java/NUM00-J.+Detect+or+prevent+integer+overflow)
[CWE-190](https://cwe.mitre.org/data/definitions/190.html)
[CWE-192](https://cwe.mitre.org/data/definitions/192.html)
[CWE-197](https://cwe.mitre.org/data/definitions/197.html)
[CWE-681](https://cwe.mitre.org/data/definitions/681.html)