### PR TITLE
winebus: Fix detection of devices with no axis.

### DIFF
--- a/dlls/winebus.sys/bus_sdl.c
+++ b/dlls/winebus.sys/bus_sdl.c
@@ -1047,7 +1047,8 @@ static void sdl_add_device(unsigned int index)
         desc.is_gamepad = (axis_count == 6  && button_count >= 14);
     }
 
-    for (axis_offset = 0; axis_offset < axis_count; axis_offset += (options.split_controllers ? 6 : axis_count))
+    axis_offset = 0;
+    do
     {
         NTSTATUS status;
 
@@ -1074,7 +1075,9 @@ static void sdl_add_device(unsigned int index)
         }
 
         bus_event_queue_device_created(&event_queue, &impl->unix_device, &desc);
+        axis_offset += (options.split_controllers ? 6 : axis_count);
     }
+    while (axis_offset < axis_count);
 }
 
 static void process_device_event(SDL_Event *event)


### PR DESCRIPTION
Cherry-picked from https://gitlab.winehq.org/wine/wine/-/merge_requests/8088 (already merged into upstream)

This patch fixes detection of devices without an axis.
This will tremendously help users with various devices like button-boxes or gear-shifters. Right now users are relying on creating virtual devices with dummy buttons, and that's not ideal :)

Closes https://github.com/ValveSoftware/Proton/issues/7427