### PR TITLE
wintrust: Initialize all cert fields in WINTRUST_AddCert.

### DIFF
--- a/dlls/wintrust/wintrust_main.c
+++ b/dlls/wintrust/wintrust_main.c
@@ -1058,6 +1058,7 @@ BOOL WINAPI WINTRUST_AddCert(CRYPT_PROVIDER_DATA *data, DWORD idxSigner,
         CRYPT_PROVIDER_CERT *cert = &data->pasSigners[idxSigner].pasCertChain[
          data->pasSigners[idxSigner].csCertChain];
 
+        memset(cert, 0, sizeof(*cert));
         cert->cbStruct = sizeof(CRYPT_PROVIDER_CERT);
         cert->pCert = CertDuplicateCertificateContext(pCert2Add);
         data->pasSigners[idxSigner].csCertChain++;


### PR DESCRIPTION
This pull request is a back port of [this upstream patch](https://gitlab.winehq.org/wine/wine/-/commit/c04dc136dd7a5aa679dcdd22535fd96e25426174) that just landed to fix [regression 58293](https://bugs.winehq.org/show_bug.cgi?id=58293) that broke binary certificate verification in some cases.

It is required to make Revive (the OculusVR to OpenVR compatability layer) work again. Without it, `LibOVR.dll` refuses to load `LibOVRRT32dll` as it does not verify. Thanks!