### PR TITLE
Update main.c for virpil devices

### DIFF
--- a/dlls/winebus.sys/main.c
+++ b/dlls/winebus.sys/main.c
@@ -529,13 +529,10 @@ static BOOL is_hidraw_enabled(WORD vid, WORD pid, const USAGE_AND_PAGE *usages, 
         if (pid == 0x0127) prefer_hidraw = TRUE; /* VKB-Sim Space Gunfighter L */
         break;
     case 0x3344:
-        /* comes with 31 buttons in the default configuration, or 128 max */
-        if ((buttons == 31) || (buttons == 128)) prefer_hidraw = TRUE;
-        /* users may have configured button limits, usually 32/50/64 */
-        if ((buttons == 32) || (buttons == 50) || (buttons == 64)) prefer_hidraw = TRUE;
-        /* if customized, arbitrary amount of buttons may be shown, decide by PID */
-        if (pid == 0x412f) prefer_hidraw = TRUE; /* Virpil Constellation ALPHA-R */
-        if (pid == 0x812c) prefer_hidraw = TRUE; /* Virpil Constellation ALPHA-L */
+        prefer_hidraw = TRUE; /* All Virpil devices */
+        /* Virpil devices have configurable VID, PID, button count, and axis count. There is no good reason to change VID, so the only valid point to grab is VID
+        currently (2025/jun/10), virpil only sells generic input devices that prefer to be HIDRAW. if they ever sold an xinput device, explicit support should be set for that alone using an if else statement to exclude it from the catchall.
+        PID is different for different generations, but must be manually changed by end users for certain games as no difference exists for L/R on some generations of devices, making arbitrary PID a commonplace. */
         break;
     case 0x03eb:
         /* users may have configured button limits, usually 32/50/64 */


### PR DESCRIPTION
changed virpil (VPC) to be a catchall to use hidraw, as this is the only thing all vpc devices want. 

vpc devices have varried button count, axis count, and even pid depending on user config. Some users may have multiple of a same, or even similar, device with identical pid, where some poorly programmed games require the user to have varried pid, thus prompting them to input their own, making it effectively random. This includes some generations of L/R sticks (common), or using multiple of the same button panel (less common).

Currently, all vpc devices are generic joystick devices that work with hidraw, and prefer it. if vpc theoretically ever released a xbox like controller, this should be an if-else to exclude the xinput device's specific pid, as no reason to change the pid would exist for that.