### PR TITLE
Fix DualSense buttons while using bluetooth

### DIFF
--- a/dlls/winebus.sys/main.c
+++ b/dlls/winebus.sys/main.c
@@ -670,11 +670,11 @@ static void process_hid_report(DEVICE_OBJECT *device, BYTE *report_buf, DWORD re
          * Extended #41 report:
          *   Prefix X  Y  Z  Rz  TriggerLeft  TriggerRight  Counter  Buttons[3] ...
          */
-        if (report->buffer[0] == 0x31 && report->length >= 11)
+        if (report->buffer[0] == 0x31 && report->length >= 12)
         {
             BYTE trigger[2];
 
-            memmove(report->buffer, report->buffer + 1, 10);
+            memmove(report->buffer, report->buffer + 1, 11);
             report->buffer[0] = 1; /* fake report #1 */
             report->length = 10;
 


### PR DESCRIPTION
Since wine 10 while using DualSense controller via bluetooth the R1 button also activated the touchpad click. The issue was that the third byte of the button report was not getting moved when the report gets remapped.
More info: https://bugs.winehq.org/show_bug.cgi?id=56883