### PR TITLE
Add NUMA topology support

### DIFF
--- a/dlls/kernel32/process.c
+++ b/dlls/kernel32/process.c
@@ -40,7 +40,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(process);
 
-/* Prototypes NUMA manquants dans certains niveaux d'API headers */
+/* Missing NUMA prototypes in some API header levels */
 extern BOOL WINAPI GetNumaHighestNodeNumber( ULONG *node );
 extern BOOL WINAPI GetNumaNodeProcessorMaskEx( USHORT node, GROUP_AFFINITY *mask );
 extern BOOL WINAPI GetNumaProximityNodeEx( ULONG proximity_id, USHORT *node );
@@ -890,7 +890,7 @@ BOOL WINAPI GetNumaProcessorNodeEx(PPROCESSOR_NUMBER processor, PUSHORT node_num
     }
     if (processor->Group != 0)
     {
-        /* Implémentation actuelle: un seul groupe supporté */
+        /* Current implementation: only one group supported */
         SetLastError(ERROR_INVALID_PARAMETER);
         return FALSE;
     }
@@ -902,7 +902,7 @@ BOOL WINAPI GetNumaProcessorNodeEx(PPROCESSOR_NUMBER processor, PUSHORT node_num
     if (!GetNumaHighestNodeNumber(&highest)) return FALSE;
     if (highest == 0)
     {
-        *node_number = 0; /* système non NUMA */
+        *node_number = 0; /* non-NUMA system */
         return TRUE;
     }
     for (n = 0; n <= highest; ++n)

--- a/dlls/kernel32/process.c
+++ b/dlls/kernel32/process.c
@@ -40,6 +40,12 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(process);
 
+/* Prototypes NUMA manquants dans certains niveaux d'API headers */
+extern BOOL WINAPI GetNumaHighestNodeNumber( ULONG *node );
+extern BOOL WINAPI GetNumaNodeProcessorMaskEx( USHORT node, GROUP_AFFINITY *mask );
+extern BOOL WINAPI GetNumaProximityNodeEx( ULONG proximity_id, USHORT *node );
+
+
 static const struct _KUSER_SHARED_DATA *user_shared_data = (struct _KUSER_SHARED_DATA *)0x7ffe0000;
 
 typedef struct
@@ -775,9 +781,17 @@ BOOL WINAPI GetFirmwareType(FIRMWARE_TYPE *type)
  */
 BOOL WINAPI GetNumaNodeProcessorMask(UCHAR node, PULONGLONG mask)
 {
-    FIXME("(%c %p): stub\n", node, mask);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+
+    GROUP_AFFINITY affinity;
+    TRACE("GetNumaNodeProcessorMask(node=%u, mask=%p)\n", node, mask);
+    if (!mask)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    if (!GetNumaNodeProcessorMaskEx(node, &affinity)) return FALSE;
+    *mask = affinity.Mask;
+    return TRUE;
 }
 
 /**********************************************************************
@@ -785,9 +799,25 @@ BOOL WINAPI GetNumaNodeProcessorMask(UCHAR node, PULONGLONG mask)
  */
 BOOL WINAPI GetNumaAvailableMemoryNode(UCHAR node, PULONGLONG available_bytes)
 {
-    FIXME("(%c %p): stub\n", node, available_bytes);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    MEMORYSTATUSEX status;
+    ULONG highest;
+    TRACE("GetNumaAvailableMemoryNode(node=%u, avail=%p)\n", node, available_bytes);
+    if (!available_bytes)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    if (!GetNumaHighestNodeNumber(&highest)) return FALSE;
+    if (node > highest)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    status.dwLength = sizeof(status);
+    if (!GlobalMemoryStatusEx(&status)) return FALSE;
+    /* Approximation: spreads free memory between known nodes */
+    *available_bytes = status.ullAvailPhys / (highest + 1);
+    return TRUE;
 }
 
 /**********************************************************************
@@ -795,9 +825,8 @@ BOOL WINAPI GetNumaAvailableMemoryNode(UCHAR node, PULONGLONG available_bytes)
  */
 BOOL WINAPI GetNumaAvailableMemoryNodeEx(USHORT node, PULONGLONG available_bytes)
 {
-    FIXME("(%hu %p): stub\n", node, available_bytes);
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    /* Same approximation as the 8-bit version */
+    return GetNumaAvailableMemoryNode((UCHAR)node, available_bytes);
 }
 
 /***********************************************************************
@@ -805,14 +834,42 @@ BOOL WINAPI GetNumaAvailableMemoryNodeEx(USHORT node, PULONGLONG available_bytes
  */
 BOOL WINAPI GetNumaProcessorNode(UCHAR processor, PUCHAR node)
 {
-    TRACE("(%d, %p)\n", processor, node);
-
-    if (processor < system_info.NumberOfProcessors)
+    ULONG highest, n;
+    GROUP_AFFINITY affinity;
+    TRACE("GetNumaProcessorNode(proc=%u, node=%p)\n", processor, node);
+    if (!node)
     {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    /* Vérification basique */
+    if (processor >= system_info.NumberOfProcessors)
+    {
+        *node = 0xFF;
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    if (!GetNumaHighestNodeNumber(&highest))
+    {
+        /* if failure -> consider mono-node */
         *node = 0;
         return TRUE;
     }
-
+    
+    if (highest == 0)
+    {
+        *node = 0; /* non-NUMA system (or fallback) */
+        return TRUE;
+    }
+    for (n = 0; n <= highest; ++n)
+    {
+        if (GetNumaNodeProcessorMaskEx((USHORT)n, &affinity) && (affinity.Mask & ((ULONGLONG)1 << processor)))
+        {
+            *node = (UCHAR)n;
+            return TRUE;
+        }
+    }
+    /* Not found: invalid */
     *node = 0xFF;
     SetLastError(ERROR_INVALID_PARAMETER);
     return FALSE;
@@ -823,17 +880,63 @@ BOOL WINAPI GetNumaProcessorNode(UCHAR processor, PUCHAR node)
  */
 BOOL WINAPI GetNumaProcessorNodeEx(PPROCESSOR_NUMBER processor, PUSHORT node_number)
 {
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+    ULONG highest, n;
+    GROUP_AFFINITY affinity;
+    TRACE("GetNumaProcessorNodeEx(proc=%p, node_number=%p)\n", processor, node_number);
+    if (!processor || !node_number)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    if (processor->Group != 0)
+    {
+        /* Implémentation actuelle: un seul groupe supporté */
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    if (processor->Number >= system_info.NumberOfProcessors || processor->Number >= 8 * sizeof(affinity.Mask))
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    if (!GetNumaHighestNodeNumber(&highest)) return FALSE;
+    if (highest == 0)
+    {
+        *node_number = 0; /* système non NUMA */
+        return TRUE;
+    }
+    for (n = 0; n <= highest; ++n)
+    {
+        if (GetNumaNodeProcessorMaskEx((USHORT)n, &affinity) && (affinity.Mask & ((ULONGLONG)1 << processor->Number)))
+        {
+            *node_number = (USHORT)n;
+            return TRUE;
+        }
+    }
+    SetLastError(ERROR_INVALID_PARAMETER);
     return FALSE;
 }
 
 /***********************************************************************
  *           GetNumaProximityNode (KERNEL32.@)
  */
-BOOL WINAPI GetNumaProximityNode(ULONG  proximity_id, PUCHAR node_number)
+BOOL WINAPI GetNumaProximityNode(ULONG proximity_id, PUCHAR node_number)
 {
-    SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-    return FALSE;
+    USHORT node16;
+    TRACE("GetNumaProximityNode(proximity=%lu, node_number=%p)\n", proximity_id, node_number);
+    if (!node_number)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    if (!GetNumaProximityNodeEx(proximity_id, &node16)) return FALSE;
+    if (node16 > 0xFF)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    *node_number = (UCHAR)node16;
+    return TRUE;
 }
 
 /**********************************************************************

--- a/dlls/kernel32/process.c
+++ b/dlls/kernel32/process.c
@@ -842,7 +842,7 @@ BOOL WINAPI GetNumaProcessorNode(UCHAR processor, PUCHAR node)
         SetLastError(ERROR_INVALID_PARAMETER);
         return FALSE;
     }
-    /* Vérification basique */
+    /* basic validation */
     if (processor >= system_info.NumberOfProcessors)
     {
         *node = 0xFF;

--- a/dlls/kernelbase/memory.c
+++ b/dlls/kernelbase/memory.c
@@ -30,6 +30,7 @@
 #include "winbase.h"
 #include "winnls.h"
 #include "winternl.h"
+#define __WINESRC__
 #include "winerror.h"
 #include "ddk/wdm.h"
 
@@ -40,7 +41,7 @@
 WINE_DEFAULT_DEBUG_CHANNEL(heap);
 WINE_DECLARE_DEBUG_CHANNEL(virtual);
 WINE_DECLARE_DEBUG_CHANNEL(globalmem);
-
+WINE_DECLARE_DEBUG_CHANNEL(numa);
 
 
 static CROSS_PROCESS_WORK_LIST *open_cross_process_connection( HANDLE process )
@@ -1429,6 +1430,134 @@ BOOL WINAPI DECLSPEC_HOTPATCH MapUserPhysicalPages( void *addr, ULONG_PTR page_c
  * NUMA functions
  ***********************************************************************/
 
+/* NUMA support using Windows logical processor information */
+static ULONG numa_highest_node_number = 0;
+static BOOL numa_initialized = FALSE;
+static RTL_CRITICAL_SECTION numa_cs;
+static RTL_CRITICAL_SECTION_DEBUG numa_cs_debug =
+{
+    0, 0, &numa_cs,
+    { &numa_cs_debug.ProcessLocksList, &numa_cs_debug.ProcessLocksList },
+    0, 0, { (DWORD_PTR)(__FILE__ ": numa_cs") }
+};
+static RTL_CRITICAL_SECTION numa_cs = { &numa_cs_debug, -1, 0, 0, 0, 0 };
+
+/* Structure to hold CPU mask for each NUMA node */
+static struct numa_node_info {
+    ULONG_PTR cpu_mask;
+    BOOL valid;
+} numa_nodes[64]; /* Windows supports up to 64 NUMA nodes */
+
+/* NUMA runtime tweak flags */
+static int numa_env_checked = 0;
+static BOOL numa_force_single = FALSE;   /* WINE_NUMA_FORCE_SINGLE=1 -> force single node */
+static BOOL numa_contig = FALSE;         /* WINE_NUMA_CONTIG=1 -> remap contiguous masks */
+
+static unsigned int popcount_ulongptr( ULONG_PTR v )
+{
+#if defined(__GNUC__)
+    return __builtin_popcountll( (unsigned long long)v );
+#else
+    unsigned int c = 0; while (v) { v &= (v-1); c++; } return c;
+#endif
+}
+
+static void initialize_numa_info(void)
+{
+    SYSTEM_LOGICAL_PROCESSOR_INFORMATION *info = NULL;
+    DWORD len = 0, i;
+    ULONG max_node = 0;
+
+    if (numa_initialized) return;
+
+    if (!numa_env_checked)
+    {
+        char buffer[256];
+        numa_env_checked = 1;
+        if (GetEnvironmentVariableA("WINE_NUMA_FORCE_SINGLE", buffer, sizeof(buffer))) numa_force_single = TRUE;
+        if (GetEnvironmentVariableA("WINE_NUMA_CONTIG", buffer, sizeof(buffer)))       numa_contig = TRUE;
+        TRACE_(numa)("NUMA env: FORCE_SINGLE=%d CONTIG=%d\n", numa_force_single, numa_contig);
+    }
+
+    memset(numa_nodes, 0, sizeof(numa_nodes));
+
+    if (!numa_force_single)
+    {
+        /* Query logical processor information to get NUMA topology */
+        if (!GetLogicalProcessorInformation(NULL, &len) && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+        {
+            info = HeapAlloc(GetProcessHeap(), 0, len);
+            if (info && GetLogicalProcessorInformation(info, &len))
+            {
+                DWORD count = len / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+                for (i = 0; i < count; i++)
+                {
+                    if (info[i].Relationship == RelationNumaNode)
+                    {
+                        ULONG node_number = info[i].NumaNode.NodeNumber;
+                        if (node_number < 64)
+                        {
+                            numa_nodes[node_number].cpu_mask = info[i].ProcessorMask;
+                            numa_nodes[node_number].valid = TRUE;
+                            if (node_number > max_node) max_node = node_number;
+                            TRACE_(numa)("NUMA raw: node=%lu mask=0x%llx\n", (unsigned long)node_number, (unsigned long long)info[i].ProcessorMask);
+                        }
+                    }
+                }
+            }
+            HeapFree(GetProcessHeap(), 0, info);
+        }
+    }
+    /* Fallback single node if requested or none discovered */
+    if (numa_force_single || (max_node == 0 && !numa_nodes[0].valid))
+    {
+        SYSTEM_INFO si; GetSystemInfo(&si);
+        numa_nodes[0].cpu_mask = (si.dwNumberOfProcessors >= (sizeof(ULONG_PTR)*8)) ? ~(ULONG_PTR)0 : ((1ULL << si.dwNumberOfProcessors) - 1);
+        numa_nodes[0].valid = TRUE; max_node = 0;
+        TRACE_(numa)("NUMA fallback single: mask=0x%llx procs=%u\n", (unsigned long long)numa_nodes[0].cpu_mask, (unsigned)popcount_ulongptr(numa_nodes[0].cpu_mask));
+    }
+    else if (numa_contig && max_node > 0)
+    {
+        /* Remap each node to a contiguous block of bits in ascending order */
+        ULONG_PTR new_masks[64] = {0}; unsigned int bit_offset = 0; BOOL ok = TRUE;
+        for (i = 0; i <= max_node; i++) if (numa_nodes[i].valid)
+        {
+            unsigned int cnt = popcount_ulongptr(numa_nodes[i].cpu_mask);
+            if (!cnt || bit_offset + cnt > sizeof(ULONG_PTR)*8) { ok = FALSE; break; }
+            new_masks[i] = (((ULONG_PTR)1 << cnt) - 1) << bit_offset;
+            TRACE_(numa)("NUMA remap: node=%lu raw=0x%llx cnt=%u -> contig=0x%llx base=%u\n",
+                  (unsigned long)i, (unsigned long long)numa_nodes[i].cpu_mask, cnt,
+                  (unsigned long long)new_masks[i], bit_offset);
+            bit_offset += cnt;
+        }
+        if (ok)
+        {
+            for (i = 0; i <= max_node; i++) if (numa_nodes[i].valid && new_masks[i]) numa_nodes[i].cpu_mask = new_masks[i];
+        }
+        else TRACE_(numa)("NUMA remap: aborted (ok=%d)\n", ok);
+    }
+
+    numa_highest_node_number = max_node;
+    numa_initialized = TRUE;
+    TRACE_(numa)("NUMA init done: highest_node=%lu\n", (unsigned long)numa_highest_node_number);
+}
+
+static BOOL get_numa_node_cpu_mask(UCHAR node, GROUP_AFFINITY *mask)
+{
+    RtlEnterCriticalSection(&numa_cs);
+    if (!numa_initialized) initialize_numa_info();
+    if (node >= 64 || !numa_nodes[node].valid)
+    {
+        RtlLeaveCriticalSection(&numa_cs); SetLastError(ERROR_INVALID_PARAMETER); return FALSE;
+    }
+    TRACE_(numa)("get_numa_node_cpu_mask: node=%u mask=0x%llx\n", node, (unsigned long long)numa_nodes[node].cpu_mask);
+    RtlLeaveCriticalSection(&numa_cs);
+    memset(mask, 0, sizeof(*mask));
+    mask->Group = 0; /* Single processor group for now */
+    mask->Mask = numa_nodes[node].cpu_mask;
+    TRACE_(numa)("get_numa_node_cpu_mask: returning Group=%hu Mask=0x%llx\n", mask->Group, (unsigned long long)mask->Mask);
+    return TRUE;
+}
 
 /***********************************************************************
  *             AllocateUserPhysicalPagesNuma   (kernelbase.@)
@@ -1533,10 +1662,24 @@ BOOL WINAPI SetProcessDefaultCpuSets(HANDLE process, const ULONG *cpu_set_ids, U
 /**********************************************************************
  *             GetNumaHighestNodeNumber   (kernelbase.@)
  */
-BOOL WINAPI DECLSPEC_HOTPATCH GetNumaHighestNodeNumber( ULONG *node )
+BOOL WINAPI GetNumaHighestNodeNumber( ULONG *node )
 {
-    FIXME( "semi-stub: %p\n", node );
-    *node = 0;
+    TRACE("(%p)\n", node);
+
+    if (!node)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    RtlEnterCriticalSection(&numa_cs);
+    
+    if (!numa_initialized)
+        initialize_numa_info();
+    
+    *node = numa_highest_node_number;
+    RtlLeaveCriticalSection(&numa_cs);
+    
     return TRUE;
 }
 
@@ -1544,20 +1687,48 @@ BOOL WINAPI DECLSPEC_HOTPATCH GetNumaHighestNodeNumber( ULONG *node )
 /**********************************************************************
  *             GetNumaNodeProcessorMaskEx   (kernelbase.@)
  */
-BOOL WINAPI DECLSPEC_HOTPATCH GetNumaNodeProcessorMaskEx( USHORT node, GROUP_AFFINITY *mask )
+BOOL WINAPI GetNumaNodeProcessorMaskEx( USHORT node, GROUP_AFFINITY *mask )
 {
-    FIXME( "stub: %hu %p\n", node, mask );
-    SetLastError( ERROR_CALL_NOT_IMPLEMENTED );
-    return FALSE;
+    TRACE("(%hu, %p)\n", node, mask);
+
+    if (!mask)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    return get_numa_node_cpu_mask((UCHAR)node, mask);
 }
 
 
 /***********************************************************************
  *             GetNumaProximityNodeEx   (kernelbase.@)
  */
-BOOL WINAPI DECLSPEC_HOTPATCH GetNumaProximityNodeEx( ULONG proximity_id, USHORT *node )
+BOOL WINAPI GetNumaProximityNodeEx( ULONG proximity_id, USHORT *node )
 {
-    SetLastError( ERROR_CALL_NOT_IMPLEMENTED );
+    TRACE("(%lu, %p)\n", proximity_id, node);
+
+    if (!node)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    RtlEnterCriticalSection(&numa_cs);
+    
+    if (!numa_initialized)
+        initialize_numa_info();
+        
+    /* For simplicity, assume proximity_id maps directly to node number */
+    if (proximity_id <= numa_highest_node_number)
+    {
+        *node = (USHORT)proximity_id;
+        RtlLeaveCriticalSection(&numa_cs);
+        return TRUE;
+    }
+    
+    RtlLeaveCriticalSection(&numa_cs);
+    SetLastError(ERROR_INVALID_PARAMETER);
     return FALSE;
 }
 

--- a/dlls/kernelbase/memory.c
+++ b/dlls/kernelbase/memory.c
@@ -30,7 +30,6 @@
 #include "winbase.h"
 #include "winnls.h"
 #include "winternl.h"
-#define __WINESRC__
 #include "winerror.h"
 #include "ddk/wdm.h"
 

--- a/dlls/kernelbase/thread.c
+++ b/dlls/kernelbase/thread.c
@@ -498,7 +498,34 @@ BOOL WINAPI SetThreadErrorMode( DWORD mode, DWORD *old )
 BOOL WINAPI DECLSPEC_HOTPATCH SetThreadGroupAffinity( HANDLE thread, const GROUP_AFFINITY *new,
                                                       GROUP_AFFINITY *old )
 {
+    GROUP_AFFINITY local_old;
+
     if (old && !GetThreadGroupAffinity( thread, old )) return FALSE;
+
+    /* Debug: log requested group/mask and previous affinity if available */
+    if (new)
+    {
+        TRACE("SetThreadGroupAffinity: thread=%p new->Group=%hu new->Mask=0x%llx\n",
+              thread, new->Group, (unsigned long long)new->Mask);
+    }
+    else
+    {
+        TRACE("SetThreadGroupAffinity: thread=%p new=NULL\n", thread);
+    }
+
+    if (old)
+    {
+        TRACE("SetThreadGroupAffinity: previous old->Group=%hu old->Mask=0x%llx\n",
+              old->Group, (unsigned long long)old->Mask);
+    }
+    else
+    {
+        /* If caller didn't supply 'old', fetch it locally for logging */
+        if (GetThreadGroupAffinity(thread, &local_old))
+            TRACE("SetThreadGroupAffinity: fetched previous Group=%hu Mask=0x%llx\n",
+                  local_old.Group, (unsigned long long)local_old.Mask);
+    }
+
     return set_ntstatus( NtSetInformationThread( thread, ThreadGroupInformation, new, sizeof(*new) ));
 }
 


### PR DESCRIPTION
This pull request implements and improves NUMA (Non-Uniform Memory Access) support in Wine, moving several NUMA-related functions from stub implementations to functional ones. It introduces logic to detect and manage NUMA nodes, CPU masks, and proximity information, and adds runtime configuration via environment variables. The changes affect both `kernel32` and `kernelbase` modules.

Key improvements and implementations:

**NUMA core logic and initialization:**

* Implements NUMA node detection and CPU mask management in `dlls/kernelbase/memory.c`, including initialization routines that use Windows processor information to map CPUs to NUMA nodes. Supports up to 64 nodes and allows runtime tweaks via `WINE_NUMA_FORCE_SINGLE` and `WINE_NUMA_CONTIG` environment variables.
* Adds a helper function to retrieve a node's CPU mask and manages NUMA state with critical sections for thread safety.

**NUMA API implementations:**

* Implements `GetNumaHighestNodeNumber`, `GetNumaNodeProcessorMaskEx`, and `GetNumaProximityNodeEx` in `dlls/kernelbase/memory.c`, replacing stubs. These functions now provide real NUMA information or fall back to single-node logic when appropriate.
* Adds missing prototypes for these NUMA APIs in `dlls/kernel32/process.c` and updates `kernel32` NUMA functions (`GetNumaNodeProcessorMask`, `GetNumaAvailableMemoryNode`, `GetNumaAvailableMemoryNodeEx`, `GetNumaProcessorNode`, `GetNumaProcessorNodeEx`, `GetNumaProximityNode`) to use the new implementations, replacing stubs and improving error handling. [[1]](diffhunk://#diff-27b1433ccf05ceba376fc80c98bb6fe84ee2677feb533bac2c42e09ec54afd51R43-R48) [[2]](diffhunk://#diff-27b1433ccf05ceba376fc80c98bb6fe84ee2677feb533bac2c42e09ec54afd51L778-R872) [[3]](diffhunk://#diff-27b1433ccf05ceba376fc80c98bb6fe84ee2677feb533bac2c42e09ec54afd51L826-R916) [[4]](diffhunk://#diff-27b1433ccf05ceba376fc80c98bb6fe84ee2677feb533bac2c42e09ec54afd51L835-R940)

**Debugging and tracing improvements:**

* Adds a dedicated `numa` debug channel and enhances tracing for NUMA and thread group affinity APIs, aiding diagnostics and development. [[1]](diffhunk://#diff-9b0176990774bf5985525971d42f9ea9c9cda8ddc438af5f0c2cc50743248735L43-R44) [[2]](diffhunk://#diff-0b14a36fc7a2ec5d6d042ef466e0cbd0174e4eca34a58e8d7b650b6f07c70300R501-R528)

These changes collectively provide functional NUMA support in Wine, improving compatibility with applications that rely on NUMA APIs and system topology information.

**Context**
I have been enjoying my topology under wine with Open X-Ray engine forks like IX-Ray or AOE that use MSVC to implement concurrency in the game for a while now and it works very nicely. With NTsync too! No need to patch `concrt140.dll`. Checkout https://bugs.winehq.org/show_bug.cgi?id=58584 for more details.