### PR TITLE
mshtml/msxml3: Fix JavaScript dispatch, event handling, and XML parsing for Adobe installers

### DIFF
--- a/dlls/mshtml/dispex.c
+++ b/dlls/mshtml/dispex.c
@@ -2315,7 +2315,10 @@ static HRESULT WINAPI DispatchEx_InvokeEx(IWineJSDispatchHost *iface, DISPID id,
     if(!ensure_real_info(This))
         return E_OUTOFMEMORY;
 
-    if(This->jsdisp)
+    /* Don't delegate dynamic property DISPIDs to jscript - they are mshtml-specific
+     * and jscript doesn't know about them. This is needed for native code that
+     * creates properties on window via GetDispID+InvokeEx (e.g. Adobe installer's JSObject). */
+    if(This->jsdisp && !is_dynamic_dispid(id))
         return IWineJSDispatch_InvokeEx(This->jsdisp, id, lcid, wFlags, pdp, pvarRes, pei, pspCaller);
 
     switch(wFlags) {

--- a/dlls/mshtml/htmlelem.c
+++ b/dlls/mshtml/htmlelem.c
@@ -1168,6 +1168,17 @@ static HRESULT WINAPI HTMLElement_setAttribute(IHTMLElement *iface, BSTR strAttr
 
     TRACE("(%p)->(%s %s %08lx)\n", This, debugstr_w(strAttributeName), debugstr_variant(&AttributeValue), lFlags);
 
+    /* Event handler attributes (onclick, onload, etc.) need to go through Wine's event system
+     * even in IE9+ mode, since Gecko doesn't dispatch events through our event handlers. */
+    if(compat_mode >= COMPAT_MODE_IE9 && This->dom_element &&
+       strAttributeName[0] && (strAttributeName[0] == 'o' || strAttributeName[0] == 'O') &&
+       strAttributeName[1] && (strAttributeName[1] == 'n' || strAttributeName[1] == 'N')) {
+        hres = set_node_event_handler_by_attr(&This->node, strAttributeName, &val);
+        if(SUCCEEDED(hres))
+            goto done;
+        /* If the event isn't recognized, fall through to the normal attribute handling */
+    }
+
     if(compat_mode < COMPAT_MODE_IE9 || !This->dom_element) {
         hres = dispex_get_id(&This->node.event_target.dispex, translate_attr_name(strAttributeName, compat_mode),
                 (lFlags&ATTRFLAG_CASESENSITIVE ? fdexNameCaseSensitive : fdexNameCaseInsensitive) | fdexNameEnsure, &dispid);

--- a/dlls/mshtml/htmlevent.c
+++ b/dlls/mshtml/htmlevent.c
@@ -4746,28 +4746,42 @@ HRESULT set_event_handler(EventTarget *event_target, eventid_t eid, VARIANT *var
         return set_event_handler_disp(event_target, eid, V_DISPATCH(var));
 
     case VT_BSTR: {
-        VARIANT *v;
-        HRESULT hres;
+        HTMLInnerWindow *script_global;
+        IDispatch *disp;
 
-        if(!use_event_quirks(event_target))
-            FIXME("Setting to string %s not supported\n", debugstr_w(V_BSTR(var)));
+        /* Compile the string into a callable function using the script engine */
+        script_global = get_script_global(&event_target->dispex);
+        if(script_global) {
+            TRACE("Compiling event handler string: %s\n", debugstr_w(V_BSTR(var)));
+            disp = script_parse_event(script_global, V_BSTR(var));
+            IHTMLWindow2_Release(&script_global->base.IHTMLWindow2_iface);
+            if(disp) {
+                HRESULT hres = set_event_handler_disp(event_target, eid, disp);
+                IDispatch_Release(disp);
+                return hres;
+            }
+            WARN("Failed to compile event handler string\n");
+        }
 
-        /*
-         * Setting event handler to string is a rare case and we don't want to
-         * complicate nor increase memory of listener_container_t for that. Instead,
-         * we store the value in DispatchEx, which can already handle custom
-         * properties.
-         */
-        remove_event_handler(event_target, eid);
+        /* Fallback: store the value in DispatchEx for quirks mode compatibility */
+        if(use_event_quirks(event_target)) {
+            VARIANT *v;
+            HRESULT hres;
 
-        hres = get_event_dispex_ref(event_target, eid, TRUE, &v);
-        if(FAILED(hres))
-            return hres;
+            remove_event_handler(event_target, eid);
 
-        V_BSTR(v) = SysAllocString(V_BSTR(var));
-        if(!V_BSTR(v))
-            return E_OUTOFMEMORY;
-        V_VT(v) = VT_BSTR;
+            hres = get_event_dispex_ref(event_target, eid, TRUE, &v);
+            if(FAILED(hres))
+                return hres;
+
+            V_BSTR(v) = SysAllocString(V_BSTR(var));
+            if(!V_BSTR(v))
+                return E_OUTOFMEMORY;
+            V_VT(v) = VT_BSTR;
+            return S_OK;
+        }
+
+        FIXME("Setting to string %s not supported (no script global)\n", debugstr_w(V_BSTR(var)));
         return S_OK;
     }
 
@@ -4867,6 +4881,20 @@ void bind_target_event(HTMLDocumentNode *doc, EventTarget *event_target, const W
     }
 
     set_event_handler_disp(event_target, eid, disp);
+}
+
+HRESULT set_node_event_handler_by_attr(HTMLDOMNode *node, const WCHAR *attr_name, VARIANT *var)
+{
+    eventid_t eid;
+
+    eid = attr_to_eid(attr_name);
+    if(eid == EVENTID_LAST) {
+        WARN("Unsupported event attribute %s\n", debugstr_w(attr_name));
+        return DISP_E_UNKNOWNNAME;
+    }
+
+    TRACE("Setting event handler for %s (eid=%d)\n", debugstr_w(attr_name), eid);
+    return set_node_event(node, eid, var);
 }
 
 void update_doc_cp_events(HTMLDocumentNode *doc, cp_static_data_t *cp)

--- a/dlls/mshtml/htmlevent.h
+++ b/dlls/mshtml/htmlevent.h
@@ -109,6 +109,7 @@ HRESULT doc_init_events(HTMLDocumentNode*);
 void detach_events(HTMLDocumentNode *doc);
 HRESULT create_event_obj(DOMEvent*,HTMLDocumentNode*,IHTMLEventObj**);
 void bind_target_event(HTMLDocumentNode*,EventTarget*,const WCHAR*,IDispatch*);
+HRESULT set_node_event_handler_by_attr(HTMLDOMNode*,const WCHAR*,VARIANT*);
 HRESULT ensure_doc_nsevent_handler(HTMLDocumentNode*,nsIDOMNode*,eventid_t);
 
 void dispatch_event(EventTarget*,DOMEvent*);

--- a/dlls/mshtml/htmlnode.c
+++ b/dlls/mshtml/htmlnode.c
@@ -384,12 +384,13 @@ static const tid_t NodeList_iface_tids[] = {
     0
 };
 
+/* Note: init_info intentionally omitted - NodeList should not expose JSObject
+ * property that HTMLDOMNode_init_dispex_info would add via HTMLDOMNode. */
 dispex_static_data_t NodeList_dispex = {
     .id         = PROT_NodeList,
     .vtbl       = &HTMLDOMChildrenCollection_dispex_vtbl,
     .disp_tid   = DispDOMChildrenCollection_tid,
     .iface_tids = NodeList_iface_tids,
-    .init_info  = HTMLDOMNode_init_dispex_info,
     .js_flags   = HOSTOBJ_VOLATILE_PROPS
 };
 

--- a/dlls/msxml3/domdoc.c
+++ b/dlls/msxml3/domdoc.c
@@ -499,11 +499,415 @@ static void sax_serror(void* ctx, const xmlError* err)
     LIBXML2_CALLBACK_SERROR(doparse, err);
 }
 
+/* Check if ptr points to "<?xml" in UTF-8 or UTF-16LE format */
+static int is_xml_decl(const char *ptr, int len, int is_utf16)
+{
+    if (is_utf16)
+    {
+        /* UTF-16LE: each char is 2 bytes, second byte is 0 for ASCII */
+        if (len < 10) return 0;
+        return ptr[0] == '<' && ptr[1] == 0 &&
+               ptr[2] == '?' && ptr[3] == 0 &&
+               ptr[4] == 'x' && ptr[5] == 0 &&
+               ptr[6] == 'm' && ptr[7] == 0 &&
+               ptr[8] == 'l' && ptr[9] == 0;
+    }
+    else
+    {
+        if (len < 5) return 0;
+        return !strncmp(ptr, "<?xml", 5);
+    }
+}
+
+/* Check if char is whitespace (handles UTF-16LE) */
+static int is_ws(const char *ptr, int is_utf16)
+{
+    char c = ptr[0];
+    if (is_utf16 && ptr[1] != 0) return 0;
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+/* Check if ptr points to "</" in UTF-8 or UTF-16LE format */
+static int is_close_tag(const char *ptr, int len, int is_utf16)
+{
+    if (is_utf16)
+    {
+        if (len < 4) return 0;
+        return ptr[0] == '<' && ptr[1] == 0 && ptr[2] == '/' && ptr[3] == 0;
+    }
+    else
+    {
+        if (len < 2) return 0;
+        return ptr[0] == '<' && ptr[1] == '/';
+    }
+}
+
+/* Check if ptr points to "<" followed by a letter (start tag) */
+static int is_start_tag(const char *ptr, int len, int is_utf16)
+{
+    char c;
+    if (is_utf16)
+    {
+        if (len < 4) return 0;
+        if (ptr[0] != '<' || ptr[1] != 0) return 0;
+        c = ptr[2];
+        if (ptr[3] != 0) return 0;
+    }
+    else
+    {
+        if (len < 2) return 0;
+        if (ptr[0] != '<') return 0;
+        c = ptr[1];
+    }
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+/* Check if ptr points to ">" */
+static int is_gt(const char *ptr, int is_utf16)
+{
+    if (is_utf16)
+        return ptr[0] == '>' && ptr[1] == 0;
+    return ptr[0] == '>';
+}
+
+/* Check if ptr points to "/>" (self-closing tag end) */
+static int is_self_close(const char *ptr, int len, int is_utf16)
+{
+    if (is_utf16)
+    {
+        if (len < 4) return 0;
+        return ptr[0] == '/' && ptr[1] == 0 && ptr[2] == '>' && ptr[3] == 0;
+    }
+    if (len < 2) return 0;
+    return ptr[0] == '/' && ptr[1] == '>';
+}
+
+/* Check if ptr points to "<!" (comment, CDATA, DOCTYPE, etc.) */
+static int is_markup_decl(const char *ptr, int len, int is_utf16)
+{
+    if (is_utf16)
+    {
+        if (len < 4) return 0;
+        return ptr[0] == '<' && ptr[1] == 0 && ptr[2] == '!' && ptr[3] == 0;
+    }
+    if (len < 2) return 0;
+    return ptr[0] == '<' && ptr[1] == '!';
+}
+
+/* Check if ptr points to "<?" (PI like <?xml) */
+static int is_pi(const char *ptr, int len, int is_utf16)
+{
+    if (is_utf16)
+    {
+        if (len < 4) return 0;
+        return ptr[0] == '<' && ptr[1] == 0 && ptr[2] == '?' && ptr[3] == 0;
+    }
+    if (len < 2) return 0;
+    return ptr[0] == '<' && ptr[1] == '?';
+}
+
+/* Check if element name ends with "XMLData" (case-sensitive).
+ * ptr points to first char after '<', len is remaining buffer length.
+ * Returns 1 if element name ends with XMLData, 0 otherwise. */
+static int is_xmldata_element(const char *ptr, int len, int is_utf16)
+{
+    const char *p = ptr;
+    const char *end = ptr + len;
+    const char *name_end = NULL;
+    int char_size = is_utf16 ? 2 : 1;
+    int name_len;
+    const char *suffix_check;
+
+    /* Find end of element name (whitespace, >, or /) */
+    while (p + char_size <= end)
+    {
+        char c = p[0];
+        if (is_utf16 && p[1] != 0) { p += char_size; continue; }
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '>' || c == '/')
+        {
+            name_end = p;
+            break;
+        }
+        p += char_size;
+    }
+    if (!name_end) return 0;
+
+    name_len = (name_end - ptr) / char_size;
+    if (name_len < 7) return 0; /* "XMLData" is 7 chars */
+
+    /* Check if name ends with "XMLData" */
+    suffix_check = name_end - (7 * char_size);
+    if (is_utf16)
+    {
+        return suffix_check[0] == 'X' && suffix_check[1] == 0 &&
+               suffix_check[2] == 'M' && suffix_check[3] == 0 &&
+               suffix_check[4] == 'L' && suffix_check[5] == 0 &&
+               suffix_check[6] == 'D' && suffix_check[7] == 0 &&
+               suffix_check[8] == 'a' && suffix_check[9] == 0 &&
+               suffix_check[10] == 't' && suffix_check[11] == 0 &&
+               suffix_check[12] == 'a' && suffix_check[13] == 0;
+    }
+    else
+    {
+        return !strncmp(suffix_check, "XMLData", 7);
+    }
+}
+
+/* Wrap embedded XML content in CDATA so it becomes text, not parsed elements.
+ * Windows MSXML tolerates embedded <?xml?> declarations but libxml2 does not.
+ * Returns a newly allocated buffer that must be freed, or NULL if no changes needed. */
+static char *wrap_embedded_xml_in_cdata(const char *ptr, int len, int *new_len, xmlCharEncoding encoding)
+{
+    const char *p, *decl_start, *content_start, *content_end = NULL, *end;
+    char *result, *dst;
+    int skip_first = 0;
+    int is_utf16 = (encoding == XML_CHAR_ENCODING_UTF16LE); /* BE not handled - Windows uses LE */
+    int char_size = is_utf16 ? 2 : 1;
+    int decl_size = is_utf16 ? 10 : 5; /* "<?xml" */
+    int nesting;
+
+    TRACE("len=%d encoding=%d is_utf16=%d\n", len, encoding, is_utf16);
+
+    end = ptr + len;
+
+    /* Check if document starts with XML declaration - if so, skip it for search */
+    p = ptr;
+    while (p + char_size <= end && is_ws(p, is_utf16))
+        p += char_size;
+    if (p + decl_size <= end && is_xml_decl(p, end - p, is_utf16))
+        skip_first = 1;
+
+    /* Search for embedded <?xml declarations */
+    decl_start = NULL;
+    for (p = ptr; p + decl_size <= end; p += char_size)
+    {
+        if (is_xml_decl(p, end - p, is_utf16))
+        {
+            if (skip_first)
+            {
+                skip_first = 0;
+                continue;
+            }
+            decl_start = p;
+            break;
+        }
+    }
+
+    if (!decl_start)
+    {
+        /* No <?xml found - also check for *XMLData elements whose content should be wrapped.
+         * Pattern: <*XMLData><Element>... where Element content should remain as text. */
+        const char *xmldata_start = NULL;
+        const char *xmldata_content = NULL;
+
+        for (p = ptr; p + char_size <= end; p += char_size)
+        {
+            if (is_start_tag(p, end - p, is_utf16))
+            {
+                /* Check if this element name ends with "XMLData" */
+                if (is_xmldata_element(p + char_size, end - p - char_size, is_utf16))
+                {
+                    /* Found *XMLData element - find end of its start tag */
+                    const char *tag_end;
+                    for (tag_end = p + char_size; tag_end + char_size <= end; tag_end += char_size)
+                    {
+                        if (is_gt(tag_end, is_utf16))
+                        {
+                            xmldata_content = tag_end + char_size;
+                            break;
+                        }
+                        if (is_self_close(tag_end, end - tag_end, is_utf16))
+                            break; /* Self-closing, no content */
+                    }
+                    if (xmldata_content)
+                    {
+                        /* Check if content starts with an element (needs CDATA wrapping) */
+                        const char *content_check = xmldata_content;
+                        /* Skip whitespace */
+                        while (content_check + char_size <= end && is_ws(content_check, is_utf16))
+                            content_check += char_size;
+                        /* Check for element start that's not <? or <! */
+                        if (is_start_tag(content_check, end - content_check, is_utf16) &&
+                            !is_pi(content_check, end - content_check, is_utf16) &&
+                            !is_markup_decl(content_check, end - content_check, is_utf16))
+                        {
+                            xmldata_start = p;
+                            content_start = xmldata_content;
+                            TRACE("found *XMLData element with element content\n");
+                            break;
+                        }
+                    }
+                    xmldata_content = NULL;
+                }
+            }
+        }
+
+        if (!xmldata_start)
+        {
+            TRACE("no embedded declarations found\n");
+            return NULL;
+        }
+
+        /* Find the matching close tag for the *XMLData element */
+        nesting = 0;
+        for (p = content_start; p + char_size <= end; p += char_size)
+        {
+            if (is_start_tag(p, end - p, is_utf16))
+            {
+                const char *tag_end;
+                int is_selfclose = 0;
+                for (tag_end = p + char_size; tag_end + char_size <= end; tag_end += char_size)
+                {
+                    if (is_self_close(tag_end, end - tag_end, is_utf16))
+                    {
+                        is_selfclose = 1;
+                        break;
+                    }
+                    if (is_gt(tag_end, is_utf16))
+                        break;
+                }
+                if (!is_selfclose)
+                    nesting++;
+            }
+            else if (is_close_tag(p, end - p, is_utf16))
+            {
+                if (nesting == 0)
+                {
+                    content_end = p;
+                    break;
+                }
+                nesting--;
+            }
+        }
+        if (!content_end)
+        {
+            TRACE("could not find *XMLData element end\n");
+            return NULL;
+        }
+        goto do_wrap;
+    }
+
+    /* Find the > before the embedded declaration (end of parent start tag) */
+    content_start = NULL;
+    for (p = decl_start - char_size; p >= ptr; p -= char_size)
+    {
+        if (is_gt(p, is_utf16))
+        {
+            content_start = p + char_size;
+            break;
+        }
+    }
+    if (!content_start)
+    {
+        TRACE("could not find parent element start\n");
+        return NULL;
+    }
+
+    /* Find the matching closing tag by tracking nesting level */
+    nesting = 0;  /* Start at 0 - we're inside parent, looking for its close tag */
+    content_end = NULL;
+    for (p = decl_start; p + char_size <= end; p += char_size)
+    {
+        if (is_start_tag(p, end - p, is_utf16))
+        {
+            /* Check if this is a self-closing tag by scanning for /> or > */
+            const char *tag_end;
+            int is_selfclose = 0;
+            for (tag_end = p + char_size; tag_end + char_size <= end; tag_end += char_size)
+            {
+                if (is_self_close(tag_end, end - tag_end, is_utf16))
+                {
+                    is_selfclose = 1;
+                    break;
+                }
+                if (is_gt(tag_end, is_utf16))
+                    break;
+            }
+            if (!is_selfclose)
+                nesting++;
+        }
+        else if (is_close_tag(p, end - p, is_utf16))
+        {
+            if (nesting == 0)
+            {
+                /* This close tag is for our parent element */
+                content_end = p;
+                break;
+            }
+            nesting--;
+        }
+    }
+    if (!content_end)
+    {
+        TRACE("could not find parent element end\n");
+        return NULL;
+    }
+
+do_wrap:
+    TRACE("wrapping content in CDATA: start=%d end=%d\n",
+          (int)(content_start - ptr), (int)(content_end - ptr));
+
+    /* Create result with CDATA wrapper: <![CDATA[ ... ]]> */
+    /* Extra space: 9 chars for <![CDATA[ and 3 for ]]> = 12, doubled for UTF-16 */
+    result = malloc(len + 24 * char_size + char_size);
+    if (!result)
+        return NULL;
+
+    dst = result;
+    /* Copy everything up to content_start */
+    for (p = ptr; p < content_start; p++)
+        *dst++ = *p;
+    /* Insert <![CDATA[ */
+    if (is_utf16)
+    {
+        *dst++ = '<'; *dst++ = 0;
+        *dst++ = '!'; *dst++ = 0;
+        *dst++ = '['; *dst++ = 0;
+        *dst++ = 'C'; *dst++ = 0;
+        *dst++ = 'D'; *dst++ = 0;
+        *dst++ = 'A'; *dst++ = 0;
+        *dst++ = 'T'; *dst++ = 0;
+        *dst++ = 'A'; *dst++ = 0;
+        *dst++ = '['; *dst++ = 0;
+    }
+    else
+    {
+        memcpy(dst, "<![CDATA[", 9);
+        dst += 9;
+    }
+    /* Copy the content */
+    for (p = content_start; p < content_end; p++)
+        *dst++ = *p;
+    /* Insert ]]> */
+    if (is_utf16)
+    {
+        *dst++ = ']'; *dst++ = 0;
+        *dst++ = ']'; *dst++ = 0;
+        *dst++ = '>'; *dst++ = 0;
+    }
+    else
+    {
+        memcpy(dst, "]]>", 3);
+        dst += 3;
+    }
+    /* Copy the rest */
+    for (p = content_end; p < end; p++)
+        *dst++ = *p;
+
+    if (is_utf16)
+        *dst++ = 0;
+    *dst = '\0';
+    *new_len = dst - result - (is_utf16 ? 1 : 0);
+    return result;
+}
+
 static xmlDocPtr doparse(domdoc* This, char const* ptr, int len, xmlCharEncoding encoding)
 {
     char *ctx_encoding;
     xmlDocPtr doc = NULL;
     xmlParserCtxtPtr pctx;
+    char *modified_ptr = NULL;
+    int modified_len;
     static xmlSAXHandler sax_handler = {
         xmlSAX2InternalSubset,          /* internalSubset */
         xmlSAX2IsStandalone,            /* isStandalone */
@@ -539,10 +943,19 @@ static xmlDocPtr doparse(domdoc* This, char const* ptr, int len, xmlCharEncoding
         sax_serror                      /* serror */
     };
 
+    /* Wrap embedded XML declarations in CDATA - Windows MSXML tolerates these but libxml2 rejects them */
+    modified_ptr = wrap_embedded_xml_in_cdata(ptr, len, &modified_len, encoding);
+    if (modified_ptr)
+    {
+        ptr = modified_ptr;
+        len = modified_len;
+    }
+
     pctx = xmlCreateMemoryParserCtxt(ptr, len);
     if (!pctx)
     {
         ERR("Failed to create parser context\n");
+        free(modified_ptr);
         return NULL;
     }
 
@@ -569,6 +982,7 @@ static xmlDocPtr doparse(domdoc* This, char const* ptr, int len, xmlCharEncoding
     ctx_encoding = (char *)pctx->encoding;
     pctx->encoding = NULL;
     xmlFreeParserCtxt(pctx);
+    free(modified_ptr);
 
     /* TODO: put this in one of the SAX callbacks */
     /* create first child as a <?xml...?> */


### PR DESCRIPTION
Fixes Adobe Creative Cloud installer failing due to several Wine incompatibilities:

mshtml: Don't delegate dynamic DISPIDs to jscript (breaks JSObject bridge)
mshtml: Route event attributes through Wine's event system in IE9+ mode
mshtml: Compile event handler strings instead of storing them
mshtml: Fix NodeList exposing incorrect interfaces
msxml3: Wrap embedded XML declarations in CDATA (Windows tolerates these, libxml2 doesn't)

Enables Adobe CC installer to complete successfully, tested with Photoshop 2021 and 2025 installation