### PR TITLE
Prevent XGenericEvents from leaking memory while Steam overlay is open

### DIFF
--- a/dlls/winex11.drv/event.c
+++ b/dlls/winex11.drv/event.c
@@ -514,7 +514,12 @@ static BOOL process_events( Display *display, Bool (*filter)(Display*, XEvent*,X
     while (XCheckIfEvent( display, &event, filter, (char *)arg ))
     {
         count++;
-        if (overlay_enabled && filter_event( display, &event, (char *)overlay_filter )) continue;
+        if (overlay_enabled && filter_event( display, &event, (char *)overlay_filter )) 
+        {
+            get_event_data( &event );
+            free_event_data( &event );
+            continue;
+        }
         if (XFilterEvent( &event, None ))
         {
             /*


### PR DESCRIPTION
XCheckIfEvent calls _XStoreEventCookie which adds an XGenericEventCookie to a doubly-linked list. If we don't remove it with XGetEventData we end up with a memory leak.

More info in this comment: https://github.com/ValveSoftware/steam-for-linux/issues/11446#issuecomment-3764174787
