### PR TITLE
Add Logitech G29 wheel to custom mapping override

### DIFF
--- a/dlls/dinput/joystick_hid.c
+++ b/dlls/dinput/joystick_hid.c
@@ -49,6 +49,7 @@
 
 #define VID_LOGITECH 0x046D
 #define PID_LOGITECH_G920 0xC262
+#define PID_LOGITECH_G29 0xC24F
 
 WINE_DEFAULT_DEBUG_CHANNEL(dinput);
 
@@ -624,33 +625,70 @@ static BOOL enum_objects( struct hid_joystick *impl, const DIPROPHEADER *filter,
             case MAKELONG(HID_USAGE_GENERIC_RX, HID_USAGE_PAGE_GENERIC):
             case MAKELONG(HID_USAGE_GENERIC_RY, HID_USAGE_PAGE_GENERIC):
             case MAKELONG(HID_USAGE_GENERIC_RZ, HID_USAGE_PAGE_GENERIC):
-                if (!impl->wgi_device && impl->attrs.VendorID == VID_LOGITECH && impl->attrs.ProductID == PID_LOGITECH_G920)
+                if (!impl->wgi_device && impl->attrs.VendorID == VID_LOGITECH && (impl->attrs.ProductID == PID_LOGITECH_G920 || impl->attrs.ProductID == PID_LOGITECH_G29))
                 {
-                    if (j == HID_USAGE_GENERIC_X)
+                    switch (impl->attrs.ProductID)
                     {
-                        set_axis_type( &instance, seen_axis, 0, &axis );
-                        hack_guid = &GUID_XAxis;
-                        hack_name = L"Wheel axis";
+                    case PID_LOGITECH_G920:
+                        if (j == HID_USAGE_GENERIC_X)
+                        {
+                            set_axis_type( &instance, seen_axis, 0, &axis );
+                            hack_guid = &GUID_XAxis;
+                            hack_name = L"Wheel axis";
+                        }
+                        else if (j == HID_USAGE_GENERIC_Y)
+                        {
+                            set_axis_type( &instance, seen_axis, 2, &axis );
+                            hack_guid = &GUID_YAxis;
+                            hack_name = L"Accelerator";
+                        }
+                        else if (j == HID_USAGE_GENERIC_Z)
+                        {
+                            set_axis_type( &instance, seen_axis, 5, &axis );
+                            hack_guid = &GUID_RzAxis;
+                            hack_name = L"Brake";
+                        }
+                        else if (j == HID_USAGE_GENERIC_RZ)
+                        {
+                            instance.dwType = DIDFT_ABSAXIS | DIDFT_MAKEINSTANCE( 6 + axis++ );
+                            hack_guid = &GUID_Slider;
+                            hack_name = L"Clutch";
+                        }
+                        else WARN("unknown axis usage page %x usage %lx for Logitech G920\n", caps->usage_page, j);
+                        break;
+                    case PID_LOGITECH_G29:
+                        if (j == HID_USAGE_GENERIC_X)
+                        {
+                            set_axis_type( &instance, seen_axis, 0, &axis );
+                            hack_guid = &GUID_XAxis;
+                            hack_name = L"Wheel axis";
+                        }
+                        else if (j == HID_USAGE_GENERIC_Y)
+                        {
+                            set_axis_type( &instance, seen_axis, 2, &axis );
+                            hack_guid = &GUID_Slider;
+                            hack_name = L"Clutch";
+
+                        }
+                        else if (j == HID_USAGE_GENERIC_Z)
+                        {
+                            set_axis_type( &instance, seen_axis, 5, &axis );
+                            hack_guid = &GUID_YAxis;
+                            hack_name = L"Accelerator";
+                        }
+                        else if (j == HID_USAGE_GENERIC_RX)
+                        {
+                            instance.dwType = DIDFT_ABSAXIS | DIDFT_MAKEINSTANCE( 6 + axis++ );
+                            hack_guid = &GUID_RzAxis;
+                            hack_name = L"Brake";
+                        }
+                        else WARN("unknown axis usage page %x usage %lx for Logitech G29\n", caps->usage_page, j);
+                        break;
+                    default:
+                        set_axis_type( &instance, seen_axis, j - HID_USAGE_GENERIC_X, &axis );
+                        break;
                     }
-                    else if (j == HID_USAGE_GENERIC_Y)
-                    {
-                        set_axis_type( &instance, seen_axis, 2, &axis );
-                        hack_guid = &GUID_YAxis;
-                        hack_name = L"Accelerator";
-                    }
-                    else if (j == HID_USAGE_GENERIC_Z)
-                    {
-                        set_axis_type( &instance, seen_axis, 5, &axis );
-                        hack_guid = &GUID_RzAxis;
-                        hack_name = L"Brake";
-                    }
-                    else if (j == HID_USAGE_GENERIC_RZ)
-                    {
-                        instance.dwType = DIDFT_ABSAXIS | DIDFT_MAKEINSTANCE( 6 + axis++ );
-                        hack_guid = &GUID_Slider;
-                        hack_name = L"Clutch";
-                    }
-                    else WARN("unknown axis usage page %x usage %lx for Logitech G920\n", caps->usage_page, j);
+
                 }
                 else
                 {
@@ -1676,7 +1714,7 @@ static HRESULT hid_joystick_device_try_open( const WCHAR *path, HANDLE *device, 
         break;
     }
 
-    if (attrs->VendorID == VID_LOGITECH && attrs->ProductID == PID_LOGITECH_G920)
+    if (attrs->VendorID == VID_LOGITECH && (attrs->ProductID == PID_LOGITECH_G920 || attrs->ProductID == PID_LOGITECH_G29))
         type = DI8DEVTYPE_DRIVING | (DI8DEVTYPEDRIVING_DUALPEDALS << 8);
 
     instance->dwDevType = device_type_for_version( type, version ) | DIDEVTYPE_HID;


### PR DESCRIPTION
with this change all of the following games correctly map the g29 pedals with no manual intervention required:
1. dirt rally 2.0 (690790)
1. WRC 7 (621830)
1. FIA European Truck Racing Championship (940580)

also note that, before this change, games 2 and 3 required the file at `<gamefolder>/Common/Settings/InputDeviceConfig.lua` to be edited otherwise the game would not recognize the throttle and brake pedals