### PR TITLE
Fix racy syscall entry breaking the Unity garbage collector

### DIFF
--- a/dlls/ntdll/tests/Makefile.in
+++ b/dlls/ntdll/tests/Makefile.in
@@ -23,6 +23,7 @@ SOURCES = \
 	string.c \
 	sync.c \
 	thread.c \
+	threadctx.c \
 	threadpool.c \
 	time.c \
 	unwind.c \

--- a/dlls/ntdll/tests/threadctx.c
+++ b/dlls/ntdll/tests/threadctx.c
@@ -1,0 +1,193 @@
+/*
+ * Unit test suite for ntdll thread context behavior
+ *
+ * Copyright 2026 Hoshino Lina
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+
+#include "ntstatus.h"
+#define WIN32_NO_STATUS
+#include "windef.h"
+#include "winbase.h"
+#include "winternl.h"
+#include "wine/test.h"
+
+static void (WINAPI *pGetCurrentThreadStackLimits)(PULONG_PTR,PULONG_PTR);
+
+// 90 second max runtime, to avoid winetest timeouts
+#define MAX_RUNTIME 90
+#define THREADS 50
+#define STACK_SIZE 0x10000
+#define LOOPS 2000
+
+#ifdef __x86_64__
+#define CTX_SP Rsp
+#define CTX_IP Rip
+#endif
+#ifdef __i386__
+#define CTX_SP Esp
+#define CTX_IP Eip
+#endif
+#ifdef __arm__
+#define CTX_SP Sp
+#define CTX_IP Pc
+#endif
+#ifdef __aarch64__
+#define CTX_SP Sp
+#define CTX_IP Pc
+#endif
+
+static volatile bool looping = true;
+
+struct thread {
+    DWORD tid;
+    bool stopped;
+    HANDLE hnd;
+    CONTEXT ctx;
+    DWORD64 stack_lo;
+    DWORD64 stack_hi;
+    bool complete;
+};
+
+struct thread t[THREADS];
+
+DWORD WINAPI thread_func(LPVOID lpParameter)
+{
+    struct thread *self = lpParameter;
+
+    ULONG_PTR lo, hi;
+    pGetCurrentThreadStackLimits(&lo, &hi);
+
+    self->stack_lo = (DWORD64)lo;
+    self->stack_hi = (DWORD64)hi;
+
+    while (looping)
+        Sleep(0);
+
+    self->complete = true;
+
+    return 0;
+}
+
+static bool is_pe_map(DWORD64 addr)
+{
+    /* See server/mapping.c for the upper limits. */
+    return (addr >= 0x60000000 && addr < 0x7c000000) ||
+           (addr >= 0x600000000000 && addr < 0x700000000000) ||
+#ifdef _WIN64
+           (addr >= 0x140000000 && addr < 0x141000000);
+#else
+           (addr >= 0x400000 && addr < 0x1400000);
+#endif
+
+}
+
+static void test_context_sp(void)
+{
+    int loop;
+    bool failed_sp = false;
+    bool failed_ip = false;
+    DWORD timeout = GetTickCount() + MAX_RUNTIME * 1000;
+
+    HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+
+    pGetCurrentThreadStackLimits = (void*)GetProcAddress(hKernel32, "GetCurrentThreadStackLimits");
+    if (!pGetCurrentThreadStackLimits)
+        win_skip("GetCurrentThreadStackLimits not available.\n");
+
+    for (int i = 0; i < THREADS; i++) {
+        t[i].hnd = CreateThread(0, STACK_SIZE, thread_func, (LPVOID)&t[i], 0,
+                                &t[i].tid);
+        ok(!!t[i].hnd, "Failed to create thread");
+        if (!t[i].hnd) {
+            looping = false;
+            break;
+        }
+    }
+
+    Sleep(100);
+
+    trace("Starting %d loops of thread context fetching\n", LOOPS);
+
+    for (loop = 0; looping && loop < LOOPS && GetTickCount() < timeout;
+         loop++) {
+        for (int i = 0; i < THREADS; i++) {
+            if (SuspendThread(t[i].hnd) != (DWORD)-1) {
+                t[i].ctx.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
+
+                if (GetThreadContext(t[i].hnd, &t[i].ctx)) {
+                    bool in_sp_range = t[i].ctx.CTX_SP > t[i].stack_lo &&
+                                       t[i].ctx.CTX_SP <= t[i].stack_hi;
+                    bool in_ip_range = is_pe_map(t[i].ctx.CTX_IP);
+
+                    if (!in_sp_range) {
+                        trace("[%d/%d:%d] SP=0x%llx [%llx..%llx]\n", loop,
+                              LOOPS, i, (long long)t[i].ctx.CTX_SP,
+                              (long long)t[i].stack_lo,
+                              (long long)t[i].stack_hi);
+                        failed_sp = true;
+                    }
+
+                    if (!in_ip_range) {
+                        trace("[%d/%d:%d] IP=0x%llx\n", loop, LOOPS, i,
+                              (long long)t[i].ctx.CTX_IP);
+                        failed_ip = true;
+                    }
+
+                    t[i].stopped = true;
+                } else {
+                    ResumeThread(t[i].hnd);
+                }
+            }
+        }
+
+        for (int i = 0; i < THREADS; i++) {
+            if (t[i].stopped)
+                ResumeThread(t[i].hnd);
+
+            t[i].stopped = false;
+        }
+
+        if (failed_sp && failed_ip)
+            break;
+    }
+
+    trace("Completed %d/%d loops\n", loop, LOOPS);
+
+    looping = false;
+
+    for (int i = 0; i < THREADS; i++)
+        WaitForSingleObject(t[i].hnd, INFINITE);
+
+    ok(!failed_sp, "Invalid SP value detected");
+
+#ifdef __i386__
+    /* Known broken on i386 */
+    todo_wine
+#endif
+    ok(!failed_ip, "Invalid IP value detected");
+
+    for (int i = 0; i < THREADS; i++)
+        ok(t[i].complete, "Thread %d died unexpectedly\n", i);
+}
+
+START_TEST(threadctx) {
+    test_context_sp();
+}

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -1095,6 +1095,9 @@ NTSTATUS WINAPI NtSetContextThread( HANDLE handle, const CONTEXT *context )
         frame->rsp    = context->Rsp;
         frame->rip    = context->Rip;
         frame->eflags = context->EFlags;
+        if ((frame->restore_flags & RESTORE_FLAGS_INSTRUMENTATION) &&
+            !(frame->restore_flags & CONTEXT_INTEGER))
+            frame->r10 = context->Rip;
     }
     if (flags & CONTEXT_FLOATING_POINT)
     {
@@ -1594,6 +1597,8 @@ NTSTATUS call_user_apc_dispatcher( CONTEXT *context, ULONG_PTR arg1, ULONG_PTR a
     frame->rsp = (ULONG64)stack;
     frame->rip = (ULONG64)pKiUserApcDispatcher;
     frame->restore_flags |= CONTEXT_CONTROL;
+    if (frame->restore_flags & RESTORE_FLAGS_INSTRUMENTATION)
+        frame->r10 = frame->rip;
     return status;
 }
 
@@ -1640,6 +1645,8 @@ NTSTATUS call_user_exception_dispatcher( EXCEPTION_RECORD *rec, CONTEXT *context
     frame->rsp = (ULONG64)stack;
     frame->rip = (ULONG64)pKiUserExceptionDispatcher;
     frame->restore_flags |= CONTEXT_CONTROL;
+    if (frame->restore_flags & RESTORE_FLAGS_INSTRUMENTATION)
+        frame->r10 = frame->rip;
     return status;
 }
 
@@ -2340,7 +2347,10 @@ static BOOL handle_syscall_trap( ucontext_t *sigcontext, siginfo_t *siginfo )
     frame->rip = *(ULONG64 *)RSP_sig( sigcontext );
     frame->eflags = EFL_sig(sigcontext);
     frame->restore_flags = CONTEXT_CONTROL;
-    if (instrumentation_callback) frame->restore_flags |= RESTORE_FLAGS_INSTRUMENTATION;
+    if (instrumentation_callback) {
+        frame->r10 = frame->rip;
+        frame->restore_flags |= RESTORE_FLAGS_INSTRUMENTATION;
+    }
 
     RCX_sig( sigcontext ) = (ULONG64)frame;
     RSP_sig( sigcontext ) += sizeof(ULONG64);
@@ -2661,7 +2671,10 @@ static void sigsys_handler( int signal, siginfo_t *siginfo, void *sigcontext )
     frame->rcx = RIP_sig(ucontext);
     frame->eflags = EFL_sig(ucontext);
     frame->restore_flags = 0;
-    if (instrumentation_callback) frame->restore_flags |= RESTORE_FLAGS_INSTRUMENTATION;
+    if (instrumentation_callback) {
+        frame->r10 = frame->rip;
+        frame->restore_flags |= RESTORE_FLAGS_INSTRUMENTATION;
+    }
     RCX_sig(ucontext) = (ULONG_PTR)frame;
     R11_sig(ucontext) = frame->eflags;
     EFL_sig(ucontext) &= ~0x100;  /* clear single-step flag */
@@ -3386,7 +3399,8 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "jz 3b\n\t"
                    "testl $0x2,%edx\n\t"          /* CONTEXT_INTEGER */
                    "jnz 1b\n\t"
-                   "xchgq %r10,(%rsp)\n\t"
+                   "movq %r10,(%rsp)\n\t"         /* frame->rip */
+                   "movq 0x40(%rcx),%r10\n\t"     /* frame->r10 (original rip) */
                    "pushq %r11\n\t"
                    /* make sure that if trap flag is set the trap happens on the first instruction after iret */
                    "andq $~0x4000,(%rsp)\n\t" /* make sure NT flag is not set, or iretq will fault */
@@ -3420,6 +3434,11 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher_instrumentation,
                    __ASM_CFI(".cfi_adjust_cfa_offset 8\n\t")
                    "popq 0x80(%rcx)\n\t"
                    __ASM_CFI(".cfi_adjust_cfa_offset -8\n\t")
+                   /* Save %rip into the r10 save slot, which will be
+                    * used in the instrumentation return path.
+                    */
+                   "pushq 0x70(%rcx)\n\t"          /* frame->rip */
+                   "popq 0x40(%rcx)\n\t"           /* frame->r10 */
                    "movl $0x10000,0xb4(%rcx)\n\t"    /* frame->restore_flags <- RESTORE_FLAGS_INSTRUMENTATION */
                    "jmp " __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_prolog_end") )
 

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -459,6 +459,7 @@ struct amd64_thread_data
     DWORD                 xstate_features_size;  /* 033c */
     UINT64                xstate_features_mask;  /* 0340 */
     void                **instrumentation_callback; /* 0348 */
+    int                   sigusr1_pending;       /* 0350 */
 };
 
 C_ASSERT( sizeof(struct amd64_thread_data) <= sizeof(((struct ntdll_thread_data *)0)->cpu_data) );
@@ -2585,6 +2586,59 @@ static void quit_handler( int signal, siginfo_t *siginfo, void *sigcontext )
     abort_thread( 0 );
 }
 
+/**********************************************************************
+ *		usr1_inside_syscall
+ *
+ * Shared code to handle SIGUSR1 within a syscall.
+ */
+static void usr1_inside_syscall(struct xcontext *context)
+{
+    struct syscall_frame *frame = amd64_thread_data()->syscall_frame;
+    ULONG64 saved_compaction = 0;
+    I386_CONTEXT *wow_context;
+
+    context->c.ContextFlags = CONTEXT_FULL | CONTEXT_SEGMENTS | CONTEXT_EXCEPTION_REQUEST;
+
+    NtGetContextThread( GetCurrentThread(), &context->c );
+    if (xstate_extended_features())
+    {
+        if (xstate_compaction_enabled) frame->xstate.CompactionMask |= xstate_extended_features();
+        context_init_xstate( &context->c, &frame->xstate );
+        saved_compaction = frame->xstate.CompactionMask;
+    }
+    wait_suspend( &context->c );
+    if (xstate_extended_features()) frame->xstate.CompactionMask = saved_compaction;
+    if (context->c.ContextFlags & 0x40)
+    {
+        /* xstate is updated directly in frame's xstate */
+        context->c.ContextFlags &= ~0x40;
+        frame->restore_flags |= 0x40;
+    }
+    if ((wow_context = get_cpu_area( IMAGE_FILE_MACHINE_I386 ))
+            && (wow_context->ContextFlags & CONTEXT_I386_CONTROL) == CONTEXT_I386_CONTROL)
+    {
+        WOW64_CPURESERVED *cpu = NtCurrentTeb()->TlsSlots[WOW64_TLS_CPURESERVED];
+
+        cpu->Flags |= WOW64_CPURESERVED_FLAG_RESET_STATE;
+    }
+    NtSetContextThread( GetCurrentThread(), &context->c );
+}
+
+/**********************************************************************
+ *		deferred_sigusr1
+ *
+ * Deferred handler for SIGUSR1
+ *
+ * Called after syscall entry, on the kernel stack.
+ */
+void deferred_sigusr1(void)
+{
+    struct xcontext context;
+
+    TRACE( "handling deferred SIGUSR1, context=%p\n", &context);
+    amd64_thread_data()->sigusr1_pending = 0;
+    usr1_inside_syscall(&context);
+}
 
 /**********************************************************************
  *		usr1_handler
@@ -2594,53 +2648,35 @@ static void quit_handler( int signal, siginfo_t *siginfo, void *sigcontext )
 static void usr1_handler( int signal, siginfo_t *siginfo, void *sigcontext )
 {
     ucontext_t *ucontext = init_handler( sigcontext );
+    struct syscall_frame *frame = amd64_thread_data()->syscall_frame;
+    struct xcontext *context;
 
-    if (is_inside_syscall( ucontext ))
+    extern const void *__wine_syscall_dispatcher_save_end_ptr;
+    extern const void *__wine_syscall_dispatcher_return_ptr;
+    extern const void *__wine_syscall_dispatcher_return_end_ptr;
+    if (RIP_sig(ucontext) >= (ULONG_PTR)__wine_syscall_dispatcher_instrumentation &&
+        RIP_sig(ucontext) < (ULONG_PTR)__wine_syscall_dispatcher_save_end_ptr)
     {
-        struct syscall_frame *frame = amd64_thread_data()->syscall_frame;
-        ULONG64 saved_compaction = 0;
-        I386_CONTEXT *wow_context;
-        struct xcontext *context;
-
-        context = (struct xcontext *)(((ULONG_PTR)RSP_sig(ucontext) - 128 /* red zone */ - sizeof(*context)) & ~15);
-        if ((char *)context < (char *)ntdll_get_thread_data()->kernel_stack)
-        {
-            ERR_(seh)( "kernel stack overflow.\n" );
-            return;
-        }
-        context->c.ContextFlags = CONTEXT_FULL | CONTEXT_SEGMENTS | CONTEXT_EXCEPTION_REQUEST;
-        if (frame->restore_flags & RESTORE_FLAGS_INCOMPLETE_FRAME_CONTEXT)
-        {
-            frame->restore_flags &= ~RESTORE_FLAGS_INCOMPLETE_FRAME_CONTEXT;
-            frame->eflags = 0x200;
-            fixup_frame_fpu_state( frame, ucontext );
-        }
-        NtGetContextThread( GetCurrentThread(), &context->c );
-        if (xstate_extended_features())
-        {
-            if (xstate_compaction_enabled) frame->xstate.CompactionMask |= xstate_extended_features();
-            context_init_xstate( &context->c, &frame->xstate );
-            saved_compaction = frame->xstate.CompactionMask;
-        }
-        wait_suspend( &context->c );
-        if (xstate_extended_features()) frame->xstate.CompactionMask = saved_compaction;
-        if (context->c.ContextFlags & 0x40)
-        {
-            /* xstate is updated directly in frame's xstate */
-            context->c.ContextFlags &= ~0x40;
-            frame->restore_flags |= 0x40;
-        }
-        if ((wow_context = get_cpu_area( IMAGE_FILE_MACHINE_I386 ))
-             && (wow_context->ContextFlags & CONTEXT_I386_CONTROL) == CONTEXT_I386_CONTROL)
-        {
-            WOW64_CPURESERVED *cpu = NtCurrentTeb()->TlsSlots[WOW64_TLS_CPURESERVED];
-
-            cpu->Flags |= WOW64_CPURESERVED_FLAG_RESET_STATE;
-        }
-        NtSetContextThread( GetCurrentThread(), &context->c );
+        /* Interrupted during syscall entry. Defer the USR1. */
+        TRACE( "deferring SIGUSR1 during syscall entry (rip=0x%lx)\n", (long)RIP_sig(ucontext));
+        amd64_thread_data()->sigusr1_pending = 1;
+        return;
     }
-    else
+    else if (RIP_sig(ucontext) >= (ULONG_PTR)__wine_syscall_dispatcher_return_ptr &&
+             RIP_sig(ucontext) < (ULONG_PTR)__wine_syscall_dispatcher_return_end_ptr)
     {
+        /* Interrupted during syscall exit. Rewind the exit and handle as inside syscall. */
+        TRACE( "rewinding syscall exit due to SIGUSR1 (rip=0x%lx)\n", (long)RIP_sig(ucontext));
+        R13_sig(ucontext) = (ULONG_PTR)NtCurrentTeb();
+        RBP_sig(ucontext) = (ULONG_PTR)&frame->rbp;
+        RIP_sig(ucontext) = (ULONG_PTR)__wine_syscall_dispatcher_return_ptr;
+        RCX_sig(ucontext) = (ULONG_PTR)frame;
+        RSP_sig(ucontext) = (ULONG_PTR)frame;
+        /* Fallthrough */
+    }
+    else if (!is_inside_syscall( ucontext ))
+    {
+        /* Interrupted outside a syscall. */
         struct xcontext context;
 
         save_context( &context, ucontext );
@@ -2648,9 +2684,25 @@ static void usr1_handler( int signal, siginfo_t *siginfo, void *sigcontext )
         if (is_wow64() && context.c.SegCs == cs64_sel) context.c.ContextFlags |= CONTEXT_EXCEPTION_ACTIVE;
         wait_suspend( &context.c );
         restore_context( &context, ucontext );
+        return;
     }
-}
+    /* Otherwise, interrupted within a syscall with a consistent user context. */
 
+    context = (struct xcontext *)(((ULONG_PTR)RSP_sig(ucontext) - 128 /* red zone */ - sizeof(*context)) & ~15);
+
+    if ((char *)context < (char *)ntdll_get_thread_data()->kernel_stack)
+    {
+        ERR_(seh)( "kernel stack overflow.\n" );
+        return;
+    }
+    if (frame->restore_flags & RESTORE_FLAGS_INCOMPLETE_FRAME_CONTEXT)
+    {
+        frame->restore_flags &= ~RESTORE_FLAGS_INCOMPLETE_FRAME_CONTEXT;
+        frame->eflags = 0x200;
+        fixup_frame_fpu_state( frame, ucontext );
+    }
+    usr1_inside_syscall(context);
+}
 
 #ifdef __APPLE__
 /**********************************************************************
@@ -3142,6 +3194,33 @@ __ASM_GLOBAL_FUNC( signal_start_thread,
 /***********************************************************************
  *           __wine_syscall_dispatcher
  */
+
+/* The instrumentation entry point comes first. This allows the range between
+ * __wine_syscall_dispatcher_instrumentation and __wine_syscall_dispatcher_save_end
+ * to be considered "entering a syscall" in the SIGUSR1 handler.
+ */
+__ASM_GLOBAL_FUNC( __wine_syscall_dispatcher_instrumentation,
+#ifdef __APPLE__
+                   "movq %gs:0x30,%rcx\n\t"
+                   "movq 0x328(%rcx),%rcx\n\t"
+#else
+                   "movq %gs:0x328,%rcx\n\t"       /* amd64_thread_data()->syscall_frame */
+#endif
+                   "popq 0x70(%rcx)\n\t"           /* frame->rip */
+                   __ASM_CFI(".cfi_adjust_cfa_offset -8\n\t")
+                   __ASM_CFI_REG_IS_AT2(rip, rcx, 0xf0,0x00)
+                   "pushfq\n\t"
+                   __ASM_CFI(".cfi_adjust_cfa_offset 8\n\t")
+                   "popq 0x80(%rcx)\n\t"
+                   __ASM_CFI(".cfi_adjust_cfa_offset -8\n\t")
+                   /* Save %rip into the r10 save slot, which will be
+                    * used in the instrumentation return path.
+                    */
+                   "pushq 0x70(%rcx)\n\t"          /* frame->rip */
+                   "popq 0x40(%rcx)\n\t"           /* frame->r10 */
+                   "movl $0x10000,0xb4(%rcx)\n\t"    /* frame->restore_flags <- RESTORE_FLAGS_INSTRUMENTATION */
+                   "jmp " __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_prolog_end") )
+
 __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
 #ifdef __APPLE__
                    "movq %gs:0x30,%rcx\n\t"
@@ -3253,7 +3332,16 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "leaq -0x98(%rbp),%rcx\n"
                    "2:\n\t"
 #endif
-                   "movq 0x00(%rcx),%rax\n\t"
+                   /* If the handler was interrupted while saving context, the
+                    * SIGUSR1 is deferred. Handle it now.
+                    */
+                   "\n" __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_save_end") ":\n\t"
+                   "testl $1,%gs:0x350\n\t"        /* amd64_thread_data()->sigusr1_pending */
+                   "jz 1f\n\t"
+                   "call " __ASM_NAME("deferred_sigusr1") "\n\t"
+                   "leaq -0x98(%rbp),%rcx\n"
+
+                   "1:\tmovq 0x00(%rcx),%rax\n\t"
                    "movq 0x18(%rcx),%r11\n\t"      /* 2nd argument */
                    "movl %eax,%ebx\n\t"
                    "shrl $8,%ebx\n\t"
@@ -3288,6 +3376,12 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "movq (%rbx),%r10\n\t"          /* table->ServiceTable */
                    "callq *(%r10,%rax,8)\n\t"
                    "leaq -0x98(%rbp),%rcx\n\t"
+
+                   /* If the handler is interrupted between this point and
+                    * __wine_syscall_dispatcher_return_end below,
+                    * the syscall return will be restarted. Therefore, this
+                    * code should be idempotent.
+                    */
                    __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_return") ":\n\t"
                    "movl 0xb4(%rcx),%edx\n\t"      /* frame->restore_flags */
                    "testl $0x48,%edx\n\t"          /* CONTEXT_FLOATING_POINT | CONTEXT_XSTATE */
@@ -3405,7 +3499,8 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    /* make sure that if trap flag is set the trap happens on the first instruction after iret */
                    "andq $~0x4000,(%rsp)\n\t" /* make sure NT flag is not set, or iretq will fault */
                    "popfq\n\t"
-                   "iretq\n\t"
+                   "iretq\n"
+                   __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_return_end") ":\n"
 
                    /* pop rbp-based kernel stack cfi */
                    __ASM_CFI("\t.cfi_restore_state\n")
@@ -3418,30 +3513,6 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher_return,
                    "movl 0xb0(%rcx),%r14d\n\t"     /* frame->syscall_flags */
                    "movq %rsi,%rax\n\t"
                    "jmp " __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_return") )
-
-
-__ASM_GLOBAL_FUNC( __wine_syscall_dispatcher_instrumentation,
-#ifdef __APPLE__
-                   "movq %gs:0x30,%rcx\n\t"
-                   "movq 0x328(%rcx),%rcx\n\t"
-#else
-                   "movq %gs:0x328,%rcx\n\t"       /* amd64_thread_data()->syscall_frame */
-#endif
-                   "popq 0x70(%rcx)\n\t"           /* frame->rip */
-                   __ASM_CFI(".cfi_adjust_cfa_offset -8\n\t")
-                   __ASM_CFI_REG_IS_AT2(rip, rcx, 0xf0,0x00)
-                   "pushfq\n\t"
-                   __ASM_CFI(".cfi_adjust_cfa_offset 8\n\t")
-                   "popq 0x80(%rcx)\n\t"
-                   __ASM_CFI(".cfi_adjust_cfa_offset -8\n\t")
-                   /* Save %rip into the r10 save slot, which will be
-                    * used in the instrumentation return path.
-                    */
-                   "pushq 0x70(%rcx)\n\t"          /* frame->rip */
-                   "popq 0x40(%rcx)\n\t"           /* frame->r10 */
-                   "movl $0x10000,0xb4(%rcx)\n\t"    /* frame->restore_flags <- RESTORE_FLAGS_INSTRUMENTATION */
-                   "jmp " __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_prolog_end") )
-
 
 /***********************************************************************
  *           __wine_unix_call_dispatcher
@@ -3552,6 +3623,15 @@ asm( ".data\n\t"
      ".globl " __ASM_NAME("__wine_unix_call_dispatcher_prolog_end_ptr") "\n"
      __ASM_NAME("__wine_unix_call_dispatcher_prolog_end_ptr") ":\n\t"
      ".quad " __ASM_LOCAL_LABEL("__wine_unix_call_dispatcher_prolog_end") "\n\t"
+     ".globl " __ASM_NAME("__wine_syscall_dispatcher_save_end_ptr") "\n"
+     __ASM_NAME("__wine_syscall_dispatcher_save_end_ptr") ":\n\t"
+     ".quad " __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_save_end") "\n\t"
+     ".globl " __ASM_NAME("__wine_syscall_dispatcher_return_ptr") "\n"
+     __ASM_NAME("__wine_syscall_dispatcher_return_ptr") ":\n\t"
+     ".quad " __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_return") "\n\t"
+     ".globl " __ASM_NAME("__wine_syscall_dispatcher_return_end_ptr") "\n"
+     __ASM_NAME("__wine_syscall_dispatcher_return_end_ptr") ":\n\t"
+     ".quad " __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_return_end") "\n\t"
      ".text\n\t" );
 
 #endif  /* __x86_64__ */


### PR DESCRIPTION
Upstream bug: https://bugs.winehq.org/show_bug.cgi?id=59333
Upstream MR: https://gitlab.winehq.org/wine/wine/-/merge_requests/10419

This is a backport to proton bleeding-edge, since that (or proton 10.0) is what the majority of users affected by this are running. I verified that the new ntdll:threadctx passes in Proton and that the ntdll:exception tests do not regress (those exercise the code affected by this).

I'm opening this here early for tracking and because I already did the backport (it's quite involved), and since most of the users affected by this are running some version of Proton 10/experimental.