### PR TITLE
winegstreamer: Don't get stream ID wires crossed

### DIFF
--- a/dlls/winegstreamer/wm_reader.c
+++ b/dlls/winegstreamer/wm_reader.c
@@ -1853,6 +1853,12 @@ static HRESULT wm_reader_read_stream_sample(struct wm_reader *reader, struct wg_
 
     if (!(stream = wm_reader_get_stream_by_stream_number(reader, buffer->stream + 1)))
         return E_INVALIDARG;
+    if (stream->read_compressed)
+    {
+        buffer->stream = reader->stream_count - buffer->stream - 1;
+        if (!(stream = wm_reader_get_stream_by_stream_number(reader, buffer->stream + 1)))
+            return E_INVALIDARG;
+    }
 
     TRACE("Got buffer for '%s' stream %p.\n", get_major_type_string(stream->format.major_type), stream);
 


### PR DESCRIPTION
Applying commit 55e5a1ccea37d1bd889ab269d55b499bf131ddf9 to upstream Wine, then running this program

```c++
#include <stdio.h>
#include <windows.h>
#include <wmsdk.h>

int main(int argc, char** argv, char** envp)
{
	HMODULE wmvcore = LoadLibrary("wmvcore.dll");
	auto WMCreateSyncReader = (decltype(::WMCreateSyncReader)*)GetProcAddress(wmvcore, "WMCreateSyncReader");
	
	IWMSyncReader* sr;
	WMCreateSyncReader(NULL, 0, &sr);
	
	if (FAILED(sr->Open(L"Z:/home/walrus/Desktop/xarlib/nekopara.wmv")))
		if (FAILED(sr->Open(L"Z:/home/x3/nekopara.wmv")))
			exit(1);
	
puts("AAAA");
	sr->SetReadStreamSamples(1, true);
puts("BBBB");
	sr->SetReadStreamSamples(2, true);
puts("CCCC");
	
	for (int i=0;i<2;i++)
	{
		INSSBuffer* sample;
		QWORD a, b;
		DWORD c;
		sr->GetNextSample(i+1, &sample, &a, &b, &c, nullptr, nullptr);
		
		BYTE* buf;
		DWORD len;
		sample->GetBufferAndLength(&buf, &len);
		printf("sample %lu bytes\n", len);
		for (int i=0;i<64;i++) printf("%.2x ", buf[i]);
		puts("");
	}
}
```

returns a ``dlls/winegstreamer/wg_parser.c:401: wg_parser_stream_copy_buffer: Assertion `offset + size <= stream->map_info.size' failed.`` error, due to getting some wires crossed between the audio and video streams.

This patch re-crosses the streams, so the crossings cancel out and it stops asserting.

I originally found the issue by running https://store.steampowered.com/app/333600/NEKOPARA_Vol_1/ in a slightly modded Proton that uses Glorious Eggroll's WMV/WMA codecs, rather than the media converter. (Standard Proton also crashes at the same point; symptoms differ, but I'd suspect the same root cause. I didn't investigate standard Proton any further.)

The issue only reproduces with some WMVs; I can upload this one if you want, but it's 503MB. Probably easier to extract it from Nekopara yourself - just make reader_OpenStream dump its IStream to disk. (That's what I did.)

Since I don't know what CW-Bug-Id: \#23483 refers to (and it's probably a game I don't have), I am unable to test this patch very thoroughly.

Fair chance there are better solutions - the original patch feels like a hack, and this patch is another hack on top of that. But I don't know how such a solution would look.