### PR TITLE
Fix for clipboard in space engineers

### DIFF
--- a/dlls/ole32/clipboard.c
+++ b/dlls/ole32/clipboard.c
@@ -1899,6 +1899,10 @@ static HWND create_clipbrd_window(void);
  */
 static inline HRESULT get_clipbrd_window(ole_clipbrd *clipbrd, HWND *wnd)
 {
+
+    if ( clipbrd->window && !IsWindow(clipbrd->window) )
+        clipbrd->window = NULL;
+    
     if ( !clipbrd->window )
         clipbrd->window = create_clipbrd_window();
 


### PR DESCRIPTION
https://bugs.winehq.org/show_bug.cgi?id=59519

Fixes clipboard not working after the first use in Space Engineers and possibly other applications. After I use the clipboard "copy" command once it destroys the window and errors out for the rest of that application launch. This should just create a new target each time the user uses the "copy" command.

Had this issue for a while and someone pointed out there is a fix for it on winehq, but we could also do it here.