### PR TITLE
Add additional SGI check in window.c for Forza Horizon 6

### DIFF
--- a/dlls/winex11.drv/window.c
+++ b/dlls/winex11.drv/window.c
@@ -3607,6 +3607,7 @@ static int use_force_below_hack(void)
         cached = sgi && (
                  !strcmp(sgi, "1293830")
                  || !strcmp(sgi, "1551360")
+                 || !strcmp(sgi, "2483190")
                  );
     }
     return cached;


### PR DESCRIPTION
This game seems to have the same issue as FH4 and FH5 where a black window shows by default. So adding a check can be done for FH6 too