### PR TITLE
[Crash] win32u/vulkan: Move 'features' to function scope in vkCreateDevice.

### DIFF
--- a/dlls/win32u/vulkan.c
+++ b/dlls/win32u/vulkan.c
@@ -895,6 +895,7 @@ static VkResult win32u_vkCreateDevice( VkPhysicalDevice client_physical_device, 
     unsigned int queue_count, props_count, i;
     struct vulkan_device *device;
     struct mempool pool = {0};
+    VkPhysicalDeviceFeatures features = {0};
     VkResult res;
 
     if (TRACE_ON(vulkan))
@@ -915,8 +916,7 @@ static VkResult win32u_vkCreateDevice( VkPhysicalDevice client_physical_device, 
     device->queues = (void *)(device + 1);
     device->queue_props = (void *)(device->queues + queue_count);
 
-{
-        VkPhysicalDeviceFeatures features = {0};
+    {
         VkPhysicalDeviceFeatures2 *features2;
 
         /* Enable shaderStorageImageWriteWithoutFormat for fshack
@@ -937,7 +937,7 @@ static VkResult win32u_vkCreateDevice( VkPhysicalDevice client_physical_device, 
             features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
             create_info->pEnabledFeatures = &features;
         }
-}
+    }
 
     if (device->extensions.has_VK_WINE_openvr_device_extensions)
     {


### PR DESCRIPTION
VkPhysicalDeviceFeatures features is declared inside an inner {} block
in win32u_vkCreateDevice, but its address is stashed into
create_info->pEnabledFeatures and then dereferenced after the block ends
by convert_device_create_info() and the host vkCreateDevice call. This
was exposed when compiled using gcc16 and caused game crashes.

Originated in c67d194e7c8 ("fshack: win32u: Support vulkan scaling
according to fake resolution.").
