### PR TITLE
ntdll: Handle ARM64EC read and map notifications for copied code.

### DIFF
--- a/dlls/ntdll/signal_arm64ec.c
+++ b/dlls/ntdll/signal_arm64ec.c
@@ -33,6 +33,7 @@
 #include "wine/list.h"
 #include "ntdll_misc.h"
 #include "unwind.h"
+#include "unixlib.h"
 #include "wine/debug.h"
 #include "ntsyscalls.h"
 
@@ -723,9 +724,17 @@ static void notify_map_view_of_section( HANDLE handle, void *addr, SIZE_T size, 
     SECTION_IMAGE_INFORMATION info;
     NTSTATUS status;
 
+    if (NtQuerySection( handle, SectionImageInformation, &info, sizeof(info), NULL ))
+    {
+        if (pNotifyMemoryProtect)
+        {
+            pNotifyMemoryProtect( addr, size, protect, FALSE, 0 );
+            pNotifyMemoryProtect( addr, size, protect, TRUE, STATUS_SUCCESS );
+        }
+        return;
+    }
     if (!pNotifyMapViewOfSection) return;
     if (!NtCurrentTeb()->Tib.ArbitraryUserPointer) return;
-    if (NtQuerySection( handle, SectionImageInformation, &info, sizeof(info), NULL )) return;
     status = pNotifyMapViewOfSection( NULL, addr, NULL, size, alloc, protect );
     if (NT_SUCCESS(status)) return;
     NtUnmapViewOfSection( GetCurrentProcess(), addr );
@@ -806,17 +815,34 @@ NTSTATUS SYSCALL_API NtReadFile( HANDLE handle, HANDLE event, PIO_APC_ROUTINE ap
                                  IO_STATUS_BLOCK *io, void *buffer, ULONG length,
                                  LARGE_INTEGER *offset, ULONG *key )
 {
+    struct apply_arm64x_read_fixups_params params =
+    {
+        .handle = handle,
+        .buffer = buffer,
+        .offset = offset && offset->QuadPart >= 0 ? offset->QuadPart : -1,
+    };
     NTSTATUS status;
 
     if (pBTCpu64NotifyReadFile && enter_syscall_callback())
     {
         pBTCpu64NotifyReadFile( handle, buffer, length, FALSE, 0 );
         status = syscall_NtReadFile( handle, event, apc, apc_user, io, buffer, length, offset, key );
+        if (!status && io->Information)
+        {
+            params.size = io->Information;
+            WINE_UNIX_CALL( unix_apply_arm64x_read_fixups, &params );
+        }
         if (pBTCpu64NotifyReadFile) pBTCpu64NotifyReadFile( handle, buffer, length, TRUE, status );
         leave_syscall_callback();
         return status;
     }
-    return syscall_NtReadFile( handle, event, apc, apc_user, io, buffer, length, offset, key );
+    status = syscall_NtReadFile( handle, event, apc, apc_user, io, buffer, length, offset, key );
+    if (!status && io->Information)
+    {
+        params.size = io->Information;
+        WINE_UNIX_CALL( unix_apply_arm64x_read_fixups, &params );
+    }
+    return status;
 }
 
 NTSTATUS SYSCALL_API NtSetContextThread( HANDLE handle, const CONTEXT *context )

--- a/dlls/ntdll/unix/file.c
+++ b/dlls/ntdll/unix/file.c
@@ -6728,6 +6728,25 @@ err:
 
 
 /******************************************************************************
+ *              unixcall_apply_arm64x_read_fixups
+ */
+NTSTATUS unixcall_apply_arm64x_read_fixups( void *args )
+{
+    struct apply_arm64x_read_fixups_params *params = args;
+    enum server_fd_type type;
+    int fd, needs_close;
+
+    if (!server_get_unix_fd( params->handle, FILE_READ_DATA, &fd, &needs_close, &type, NULL ))
+    {
+        if (type == FD_TYPE_FILE)
+            virtual_apply_arm64x_read_fixups( fd, params->buffer, params->size, params->offset );
+        if (needs_close) close( fd );
+    }
+    return STATUS_SUCCESS;
+}
+
+
+/******************************************************************************
  *              NtReadFileScatter   (NTDLL.@)
  */
 NTSTATUS WINAPI NtReadFileScatter( HANDLE file, HANDLE event, PIO_APC_ROUTINE apc, void *apc_user,

--- a/dlls/ntdll/unix/loader.c
+++ b/dlls/ntdll/unix/loader.c
@@ -1427,6 +1427,7 @@ static const unixlib_entry_t unix_call_funcs[] =
     steamclient_setup_trampolines,
     debugstr_pc,
     unixcall_compat_wine_nt_to_unix_file_name,
+    unixcall_apply_arm64x_read_fixups,
 };
 
 
@@ -1510,6 +1511,11 @@ static NTSTATUS wow64_compat_wine_nt_to_unix_file_name( void *args )
     return STATUS_NOT_SUPPORTED;
 }
 
+static NTSTATUS wow64_apply_arm64x_read_fixups( void *args )
+{
+    return STATUS_SUCCESS;
+}
+
 const unixlib_entry_t unix_call_wow64_funcs[] =
 {
     wow64_load_so_dll,
@@ -1526,6 +1532,7 @@ const unixlib_entry_t unix_call_wow64_funcs[] =
     wow64_steamclient_setup_trampolines,
     wow64_debugstr_pc,
     wow64_compat_wine_nt_to_unix_file_name,
+    wow64_apply_arm64x_read_fixups,
 };
 
 #endif  /* _WIN64 */

--- a/dlls/ntdll/unix/unix_private.h
+++ b/dlls/ntdll/unix/unix_private.h
@@ -317,6 +317,7 @@ extern void virtual_map_user_shared_data(void);
 extern void virtual_init_user_shared_data(void);
 extern NTSTATUS virtual_handle_fault( EXCEPTION_RECORD *rec, void *stack );
 extern unsigned int virtual_locked_server_call( void *req_ptr );
+extern void virtual_apply_arm64x_read_fixups( int fd, void *buffer, size_t size, off_t offset );
 extern ssize_t virtual_locked_read( int fd, void *addr, size_t size );
 extern ssize_t virtual_locked_pread( int fd, void *addr, size_t size, off_t offset );
 extern ssize_t virtual_locked_recvmsg( int fd, struct msghdr *hdr, int flags );
@@ -402,6 +403,7 @@ extern NTSTATUS unixcall_wine_dbg_write( void *args );
 extern NTSTATUS unixcall_wine_server_call( void *args );
 extern NTSTATUS unixcall_wine_server_fd_to_handle( void *args );
 extern NTSTATUS unixcall_wine_server_handle_to_fd( void *args );
+extern NTSTATUS unixcall_apply_arm64x_read_fixups( void *args );
 extern NTSTATUS unixcall_wine_spawnvp( void *args );
 #ifdef _WIN64
 extern NTSTATUS wow64_wine_dbg_write( void *args );

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -3117,6 +3117,216 @@ static void apply_arm64x_relocations( char *base, const IMAGE_BASE_RELOCATION *r
     }
 }
 
+static void *get_raw_file_range( char *base, size_t file_size, size_t offset, size_t size )
+{
+    if (offset > file_size || size > file_size - offset) return NULL;
+    return base + offset;
+}
+
+static IMAGE_SECTION_HEADER *get_raw_section( IMAGE_SECTION_HEADER *sections, WORD count, DWORD rva, size_t size )
+{
+    unsigned int i;
+
+    for (i = 0; i < count; i++)
+    {
+        DWORD section_rva = sections[i].VirtualAddress;
+        DWORD section_size = sections[i].SizeOfRawData;
+
+        if (rva >= section_rva && rva - section_rva <= section_size &&
+            size <= section_size - (rva - section_rva))
+            return &sections[i];
+    }
+    return NULL;
+}
+
+static void *get_raw_rva( char *base, size_t file_size, IMAGE_NT_HEADERS64 *nt,
+                          IMAGE_SECTION_HEADER *sections, DWORD rva, size_t size )
+{
+    IMAGE_SECTION_HEADER *section;
+
+    if (rva < nt->OptionalHeader.SizeOfHeaders)
+        return get_raw_file_range( base, file_size, rva, size );
+
+    if (!(section = get_raw_section( sections, nt->FileHeader.NumberOfSections, rva, size )))
+        return NULL;
+
+    return get_raw_file_range( base, file_size, section->PointerToRawData + rva - section->VirtualAddress, size );
+}
+
+static char *get_arm64x_read_fixup_target( char *buffer, size_t read_size, off_t read_offset,
+                                           IMAGE_NT_HEADERS64 *nt, IMAGE_SECTION_HEADER *sections,
+                                           DWORD rva, size_t size )
+{
+    IMAGE_SECTION_HEADER *section;
+    size_t raw_offset;
+
+    if (rva < nt->OptionalHeader.SizeOfHeaders)
+        raw_offset = rva;
+    else
+    {
+        if (!(section = get_raw_section( sections, nt->FileHeader.NumberOfSections, rva, size )))
+            return NULL;
+        raw_offset = section->PointerToRawData + rva - section->VirtualAddress;
+    }
+
+    if (raw_offset < read_offset || size > read_size || raw_offset - read_offset > read_size - size)
+        return NULL;
+    return buffer + raw_offset - read_offset;
+}
+
+static void apply_arm64x_read_fixups( char *buffer, size_t read_size, off_t read_offset,
+                                      IMAGE_NT_HEADERS64 *nt, IMAGE_SECTION_HEADER *sections,
+                                      const IMAGE_BASE_RELOCATION *reloc, size_t size )
+{
+    const IMAGE_BASE_RELOCATION *reloc_end = (const IMAGE_BASE_RELOCATION *)((const char *)reloc + size);
+
+    while (reloc < reloc_end - 1 && reloc->SizeOfBlock >= sizeof(*reloc) &&
+           reloc->SizeOfBlock <= (const char *)reloc_end - (const char *)reloc)
+    {
+        const USHORT *rel = (const USHORT *)(reloc + 1);
+        const USHORT *rel_end = (const USHORT *)((const char *)reloc + reloc->SizeOfBlock);
+
+        while (rel < rel_end && *rel)
+        {
+            USHORT offset = *rel & 0xfff;
+            USHORT type = (*rel >> 12) & 3;
+            USHORT arg = *rel >> 14;
+            char *target;
+            int val;
+
+            rel++;
+            switch (type)
+            {
+            case IMAGE_DVRT_ARM64X_FIXUP_TYPE_ZEROFILL:
+                if ((target = get_arm64x_read_fixup_target( buffer, read_size, read_offset, nt, sections,
+                                                            reloc->VirtualAddress + offset, 1 << arg )))
+                    memset( target, 0, 1 << arg );
+                break;
+            case IMAGE_DVRT_ARM64X_FIXUP_TYPE_VALUE:
+                if ((const char *)rel + (1 << arg) > (const char *)rel_end) return;
+                if ((target = get_arm64x_read_fixup_target( buffer, read_size, read_offset, nt, sections,
+                                                            reloc->VirtualAddress + offset, 1 << arg )))
+                    memcpy( target, rel, 1 << arg );
+                rel += (1 << arg) / sizeof(USHORT);
+                break;
+            case IMAGE_DVRT_ARM64X_FIXUP_TYPE_DELTA:
+                if (rel >= rel_end) return;
+                val = (unsigned int)*rel++ * ((arg & 2) ? 8 : 4);
+                if (arg & 1) val = -val;
+                if ((target = get_arm64x_read_fixup_target( buffer, read_size, read_offset, nt, sections,
+                                                            reloc->VirtualAddress + offset, sizeof(int) )))
+                {
+                    int old_val;
+
+                    memcpy( &old_val, target, sizeof(old_val) );
+                    old_val += val;
+                    memcpy( target, &old_val, sizeof(old_val) );
+                }
+                break;
+            }
+        }
+        reloc = (const IMAGE_BASE_RELOCATION *)rel_end;
+    }
+}
+
+static void apply_arm64x_read_fixups_to_file( int fd, void *buffer, size_t read_size, off_t read_offset )
+{
+    IMAGE_DYNAMIC_RELOCATION_TABLE *table;
+    IMAGE_LOAD_CONFIG_DIRECTORY64 *cfg;
+    IMAGE_DATA_DIRECTORY *dir;
+    IMAGE_SECTION_HEADER *sections;
+    IMAGE_DOS_HEADER *dos;
+    IMAGE_NT_HEADERS64 *nt;
+    struct stat st;
+    char *base, *ptr, *end;
+
+    if (!is_arm64ec() || read_offset < 0 || fstat( fd, &st ) == -1 || st.st_size <= 0)
+        return;
+    if ((base = mmap( NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0 )) == MAP_FAILED) return;
+
+    if (!(dos = get_raw_file_range( base, st.st_size, 0, sizeof(*dos) )) ||
+        dos->e_magic != IMAGE_DOS_SIGNATURE || dos->e_lfanew < 0 ||
+        !(nt = get_raw_file_range( base, st.st_size, dos->e_lfanew, sizeof(*nt) )) ||
+        nt->Signature != IMAGE_NT_SIGNATURE || nt->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR64_MAGIC ||
+        !(nt->FileHeader.Characteristics & IMAGE_FILE_DLL) ||
+        nt->FileHeader.Machine != IMAGE_FILE_MACHINE_ARM64 ||
+        nt->OptionalHeader.NumberOfRvaAndSizes <= IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG)
+        goto done;
+
+    sections = IMAGE_FIRST_SECTION( nt );
+    if (!get_raw_file_range( base, st.st_size, (char *)sections - base,
+                             nt->FileHeader.NumberOfSections * sizeof(*sections) ))
+        goto done;
+
+    dir = &nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG];
+    if (!dir->VirtualAddress ||
+        dir->Size <= offsetof( IMAGE_LOAD_CONFIG_DIRECTORY64, DynamicValueRelocTableSection ) ||
+        !(cfg = get_raw_rva( base, st.st_size, nt, sections, dir->VirtualAddress,
+                             offsetof( IMAGE_LOAD_CONFIG_DIRECTORY64, DynamicValueRelocTableSection ) +
+                             sizeof(cfg->DynamicValueRelocTableSection) )) ||
+        !cfg->DynamicValueRelocTableSection ||
+        cfg->DynamicValueRelocTableSection > nt->FileHeader.NumberOfSections ||
+        cfg->DynamicValueRelocTableOffset >= sections[cfg->DynamicValueRelocTableSection - 1].SizeOfRawData)
+        goto done;
+
+    if (!(table = get_raw_file_range( base, st.st_size,
+                                      sections[cfg->DynamicValueRelocTableSection - 1].PointerToRawData +
+                                      cfg->DynamicValueRelocTableOffset, sizeof(*table) )) ||
+        !(ptr = get_raw_file_range( base, st.st_size, (char *)(table + 1) - base, table->Size )))
+        goto done;
+
+    end = ptr + table->Size;
+    switch (table->Version)
+    {
+    case 1:
+        while (ptr < end)
+        {
+            IMAGE_DYNAMIC_RELOCATION64 *dyn = (IMAGE_DYNAMIC_RELOCATION64 *)ptr;
+
+            if (end - ptr < sizeof(*dyn) || dyn->BaseRelocSize > end - ptr - sizeof(*dyn)) break;
+            if (dyn->Symbol == IMAGE_DYNAMIC_RELOCATION_ARM64X)
+            {
+                apply_arm64x_read_fixups( buffer, read_size, read_offset, nt, sections,
+                                          (IMAGE_BASE_RELOCATION *)(dyn + 1), dyn->BaseRelocSize );
+                break;
+            }
+            ptr += sizeof(*dyn) + dyn->BaseRelocSize;
+        }
+        break;
+    case 2:
+        while (ptr < end)
+        {
+            IMAGE_DYNAMIC_RELOCATION64_V2 *dyn = (IMAGE_DYNAMIC_RELOCATION64_V2 *)ptr;
+
+            if (end - ptr < sizeof(*dyn) || dyn->HeaderSize < sizeof(*dyn) ||
+                dyn->HeaderSize > end - ptr || dyn->FixupInfoSize > end - ptr - dyn->HeaderSize)
+                break;
+            if (dyn->Symbol == IMAGE_DYNAMIC_RELOCATION_ARM64X)
+            {
+                apply_arm64x_read_fixups( buffer, read_size, read_offset, nt, sections,
+                                          (IMAGE_BASE_RELOCATION *)(ptr + dyn->HeaderSize), dyn->FixupInfoSize );
+                break;
+            }
+            ptr += dyn->HeaderSize + dyn->FixupInfoSize;
+        }
+        break;
+    }
+
+done:
+    munmap( base, st.st_size );
+}
+
+void virtual_apply_arm64x_read_fixups( int fd, void *buffer, size_t size, off_t offset )
+{
+    if (!size) return;
+    if (offset < 0)
+    {
+        if ((offset = lseek( fd, 0, SEEK_CUR )) >= size) offset -= size;
+        else offset = -1;
+    }
+
+    if (offset >= 0) apply_arm64x_read_fixups_to_file( fd, buffer, size, offset );
+}
 
 /***********************************************************************
  *           update_arm64x_mapping
@@ -3173,6 +3383,16 @@ static void update_arm64x_mapping( struct file_view *view, IMAGE_NT_HEADERS *nt,
 }
 
 #endif  /* __aarch64__ */
+
+#ifndef __aarch64__
+void virtual_apply_arm64x_read_fixups( int fd, void *buffer, size_t size, off_t offset )
+{
+    (void)fd;
+    (void)buffer;
+    (void)size;
+    (void)offset;
+}
+#endif
 
 /***********************************************************************
  *           get_data_dir

--- a/dlls/ntdll/unixlib.h
+++ b/dlls/ntdll/unixlib.h
@@ -108,6 +108,14 @@ struct compat_wine_nt_to_unix_file_name_params
     unsigned int disposition;
 };
 
+struct apply_arm64x_read_fixups_params
+{
+    HANDLE   handle;
+    void    *buffer;
+    SIZE_T   size;
+    LONGLONG offset;
+};
+
 enum ntdll_unix_funcs
 {
     unix_load_so_dll,
@@ -124,6 +132,7 @@ enum ntdll_unix_funcs
     unix_steamclient_setup_trampolines,
     unix_debugstr_pc,
     unix_compat_wine_nt_to_unix_file_name,
+    unix_apply_arm64x_read_fixups,
 };
 
 extern unixlib_handle_t __wine_unixlib_handle;


### PR DESCRIPTION
Fixes Starcraft II x64 client on arm64 (NVIDIA DGX Spark), along with https://github.com/FEX-Emu/FEX/pull/5508 and https://github.com/FEX-Emu/FEX/pull/5510

BEFORE:

<img width="201" height="120" alt="image" src="https://github.com/user-attachments/assets/6fa5fd8c-00a3-420c-8a59-d3573c6872f6" />

AFTER:

<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/65f525be-8221-4fe6-a9b4-ea641a3f8b4b" />
# Wine ARM64EC Read And Map Follow-up

This note describes a Wine-side ARM64EC fix needed by StarCraft II's x64 client
when running through ARM64 Proton on FEX.

## Summary

StarCraft II's x64 client exercises two ARM64EC cases where Wine has better
source information than the emulator:

- An executable non-image section view can replace an earlier image mapping, but
  the ARM64EC notification path only reports the image map.
- The process can read ARM64EC DLL bytes into a private buffer and execute copied
  syscall wrapper code from that buffer, bypassing the normal image loader path
  that applies ARM64X dynamic-value fixups.

The proposed fix handles both cases in Wine:

- report successful executable non-image section mappings through the existing
  ARM64EC memory-protection notification callback;
- apply ARM64X dynamic-value fixups to synchronous `NtReadFile` buffers when the
  source file is an ARM64EC image that contains the relevant metadata.

This prevents the emulator from having to infer missing Wine state later from an
execution-time fault or decode miss.

## Executable Non-image Section Maps

Wine already notifies ARM64EC support code when mapping image views. StarCraft II
also creates executable non-image section views that can occupy an address range
previously associated with an image view.

If that later mapping is not reported, the emulator may keep stale executable
range metadata for the old view. The fix is to extend the ARM64EC
`NtMapViewOfSection` notification path so successful non-image maps report their
final protection through the existing `pNotifyMemoryProtect()` callback.

The important properties are:

- notify only after `NtMapViewOfSection` succeeds;
- use the final mapped base, size, and protection returned by Wine;
- keep image-map notifications on the existing image path;
- use the memory-protection callback for non-image mappings rather than adding a
  new emulator-side reconstruction path.

## Copied ARM64EC Syscall Wrapper Bytes

Wine's normal ARM64EC image mapping path applies ARM64X dynamic-value
relocations while loading images. A plain file read does not go through that
loader path.

StarCraft II reads ARM64EC DLL bytes into a private buffer and later executes
copied syscall wrapper code from that buffer. Without applying the ARM64X
dynamic-value fixups to the copied bytes, the private copy can differ from the
code Wine would have produced for a mapped ARM64EC image.

The fix is to wrap ARM64EC `NtReadFile` so that, after a successful synchronous
read, Wine asks the Unix side to inspect the backing file and apply ARM64X
dynamic-value fixups to the read buffer when appropriate.

The implementation should:

- only run after successful synchronous reads with known byte ranges;
- inspect the source file as a PE image and locate the ARM64X dynamic-value
  relocation metadata;
- apply fixups only to records whose file offsets overlap the bytes returned to
  the caller;
- leave unrelated files and unrelated read ranges untouched;
- reuse Wine's existing ARM64X relocation concepts instead of hard-coding
  syscall thunk byte patterns.

## Files Touched In The Prototype

The prototype patch is limited to `ntdll`:

```text
dlls/ntdll/signal_arm64ec.c
dlls/ntdll/unix/file.c
dlls/ntdll/unix/loader.c
dlls/ntdll/unix/unix_private.h
dlls/ntdll/unix/virtual.c
dlls/ntdll/unixlib.h
```

The public ARM64EC syscall wrapper lives in `signal_arm64ec.c`. The Unix-side
file descriptor handling is in `file.c`. The PE/ARM64X inspection and relocation
application live in `virtual.c`, with small declarations and unixlib plumbing in
the remaining files.

## Why Not Fix This In FEX

Two emulator-side workarounds were considered:

- lazily rebuilding executable tracking after a missing executable range;
- rewriting copied Wine syscall thunks immediately before decode.

Both solve symptoms after Wine has already lost or bypassed the relevant state.
Wine knows the section mapping result, file descriptor, read offset, and ARM64X
metadata at the time the operations occur. Handling the cases in Wine keeps the
emulator interface explicit and avoids making FEX guess which mappings or copied
buffers came from ARM64EC Wine internals.

## Validation

With the Wine changes rebuilt into ARM64 Proton, and with the remaining FEX
privileged-instruction handling fix applied, StarCraft II's x64 client launches
through its 64-bit switcher and creates a normal full-size game window.

The Proton log still contains repeated handled illegal-instruction exceptions
from StarCraft II's protected startup probes after the window is alive. Those
exceptions are expected for this title and are not the startup failure that the
Wine changes address.
