### PR TITLE
belauncher: Prepend install path for game_exe starting with backslash.

### DIFF
--- a/programs/belauncher/main.c
+++ b/programs/belauncher/main.c
@@ -169,7 +169,16 @@ int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPWSTR cmdline, int cm
     battleye_status = 0x9; /* Launching Game */
     _write(1, &battleye_status, 1);
 
-    if (PathIsRelativeW(game_exeW) || game_exeW[0] == L'\\')
+    /* Windows BattlEye treats a singleton leading-backslash 64BitExe as
+     * install-relative; strip it so the joined launch_cmd doesn't end up
+     * with a doubled separator.  Skip if a second '\' follows so UNC paths
+     * are preserved. */
+    if (game_exeW[0] == L'\\' && game_exeW[1] != L'\\')
+    {
+        memmove(game_exeW, game_exeW + 1, game_exe_len * sizeof(*game_exeW));
+        --game_exe_len;
+    }
+    if (PathIsRelativeW(game_exeW))
         path_len = wcslen(path);
     else
         path_len = 0;

--- a/programs/belauncher/main.c
+++ b/programs/belauncher/main.c
@@ -169,7 +169,7 @@ int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPWSTR cmdline, int cm
     battleye_status = 0x9; /* Launching Game */
     _write(1, &battleye_status, 1);
 
-    if (PathIsRelativeW(game_exeW))
+    if (PathIsRelativeW(game_exeW) || game_exeW[0] == L'\\')
         path_len = wcslen(path);
     else
         path_len = 0;


### PR DESCRIPTION
`belauncher.exe` fails to launch the game when a title's `BELauncher.ini` specifies a `64BitExe=` value with a leading backslash (a Win32 "root-relative" path), e.g.:

```ini
64BitExe=\Game\Binaries\Win64\Game.exe
```

The existing guard in `programs/belauncher/main.c` only prepends the install directory when `PathIsRelativeW(game_exeW)` returns TRUE, however, `PathIsRelativeW` returns FALSE for any path whose first character is `\` (per the implementation in `dlls/kernelbase/path.c`)


Reproduced under Proton Experimental (11.0-20260518b) with a title whose `BELauncher.ini` uses a leading-backslash `64BitExe=`. With `WINEDEBUG=+belauncher`:

```
trace:belauncher:wWinMain PROTON_ORIG_LAUNCHER_NAME L"S:\common\<Game>\<Game>.exe".
trace:belauncher:wWinMain cmdline L"-XRRuntime=... -d3d11".
trace:belauncher:wWinMain Launching original launcher L"S:\common\<Game>\<Game>.exe".
trace:belauncher:wWinMain Launching game executable \<Game>\Binaries\Win64\<Game>.exe for BattlEye.
trace:belauncher:wWinMain game_exe L"\<Game>\Binaries\Win64\<Game>.exe".
trace:belauncher:wWinMain path L"S:\common\<Game>\", be_arg (null).
trace:belauncher:wWinMain launch_cmd L"\<Game>\Binaries\Win64\<Game>.exe -XRRuntime=... -d3d11".
err:belauncher:wWinMain CreateProcessW failed, error 2.
```

Note `launch_cmd` is missing the `path` prefix, even though `path` is known and traced one line earlier. The file at `S:\common\<Game>\<Game>\Binaries\Win64\<Game>.exe` exists; the path Wine actually queried (`<current_drive>:\<Game>\Binaries\Win64\<Game>.exe`) does not.

Editing the title's `BELauncher.ini` to remove the leading backslash makes the launch succeed, confirming the diagnosis.

P.S this fixes Contractors Showdown/Exfilzone which is yet another W for the steam frame