### PR TITLE
MSFS multiline text repeating workaround

### DIFF
--- a/dlls/user32/edit.c
+++ b/dlls/user32/edit.c
@@ -4385,6 +4385,8 @@ static LRESULT EDIT_WM_NCCreate(HWND hwnd, LPCREATESTRUCTW lpcs, BOOL unicode)
 	EDITSTATE *es;
 	UINT alloc_size;
 
+	if ((EDITSTATE*)GetWindowLongPtrW(hwnd, 0)) return TRUE;
+
 	TRACE("Creating %s edit control, style = %08lx\n",
 		unicode ? "Unicode" : "ANSI", lpcs->style);
 


### PR DESCRIPTION
This is the fix proposed by Tom Brazier in the 2019-09-11 15:12:38 UTC comment on https://bugs.winehq.org/show_bug.cgi?id=43493