### PR TITLE
winebus: Enable hidraw by default for Winwing Orion controllers.

### DIFF
--- a/dlls/winebus.sys/main.c
+++ b/dlls/winebus.sys/main.c
@@ -654,6 +654,11 @@ static BOOL is_hidraw_enabled(WORD vid, WORD pid, const USAGE_AND_PAGE *usages, 
         if ((buttons == 32) || (buttons == 50) || (buttons == 64)) prefer_hidraw = TRUE;
         if (pid == 0x2055) prefer_hidraw = TRUE; /* ATMEL/VIRPIL/200325 VPC Throttle MT-50 CM2 */
         break;
+    case 0x4098:
+        if (pid == 0xbea8) prefer_hidraw = TRUE; /* Winwing Orion Joystick Base 2 */
+        if (pid == 0xbd64) prefer_hidraw = TRUE; /* Winwing Orion Throttle Base II */
+        if (pid == 0xbef0) prefer_hidraw = TRUE; /* Winwing Orion Combat Rudder Pedals */
+        break;
     }
 
     RtlInitUnicodeString(&str, L"EnableHidraw");


### PR DESCRIPTION
Winebus may expose Winwing Orion flight hardware through SDL's synthesized gamepad path, which can produce an XInput-compatible device and hide axes or buttons available through the original HID reports.

This happened to me with (only) Orion Joystick (rest was okay) for Star Wars Squadron game making it bugged controller. I had to go to Protontricks and change protons aggressive remaping by forcing WINEBUS\WINE_COMP_HID:

```
Service: Changed from xinput to winehid
DeviceDesc: Changed to Wine HID compatible device
CompatibleIds: Changed to WINEBUS\WINE_COMP_HID (was already there, but first line was something else)
```
That fixed the issue, so it's also verified by me. This change uses winebus's existing hidraw preference mechanism so the raw HID interface wins during device arbitration.

The VID:PID match also applies to every interface exposed by these composite USB devices.

```
4098:bea8 — Winwing Orion Joystick Base Metal 2
4098:bd64 — Winwing Orion Throttle Base II
4098:bef0 — Winwing Orion Combat Rudder Pedals
```