### PR TITLE
windows.ui.core.textinput: Return success from CoreInputView Try* methods

### DIFF
--- a/dlls/windows.ui.core.textinput/Makefile.in
+++ b/dlls/windows.ui.core.textinput/Makefile.in
@@ -1,5 +1,5 @@
 MODULE  = windows.ui.core.textinput.dll
-IMPORTS = combase
+IMPORTS = combase user32
 
 SOURCES = \
 	classes.idl \

--- a/dlls/windows.ui.core.textinput/main.c
+++ b/dlls/windows.ui.core.textinput/main.c
@@ -23,6 +23,8 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(coreinputview);
 
+#define WM_TABTIP_OSK_TOGGLE (WM_USER + 1)
+
 struct core_input_view
 {
     ICoreInputView ICoreInputView_iface;
@@ -30,6 +32,7 @@ struct core_input_view
     ICoreInputView3 ICoreInputView3_iface;
     ICoreInputView4 ICoreInputView4_iface;
     struct weak_reference_source weak_reference_source;
+    HWND tabtip_hwnd;
 };
 
 static inline struct core_input_view *impl_from_ICoreInputView(ICoreInputView *iface)
@@ -159,7 +162,12 @@ static HRESULT WINAPI core_input_view_GetCoreInputViewOcclusions(ICoreInputView 
 
 static HRESULT WINAPI core_input_view_TryShowPrimaryView(ICoreInputView *iface, boolean *result)
 {
+    struct core_input_view *impl = impl_from_ICoreInputView(iface);
+
     FIXME("iface %p, boolean %p semi-stub!\n", iface, result);
+
+    if (impl->tabtip_hwnd)
+        PostMessageW(impl->tabtip_hwnd, WM_TABTIP_OSK_TOGGLE, TRUE, 0);
 
     *result = FALSE;
     return S_OK;
@@ -167,7 +175,12 @@ static HRESULT WINAPI core_input_view_TryShowPrimaryView(ICoreInputView *iface, 
 
 static HRESULT WINAPI core_input_view_TryHidePrimaryView(ICoreInputView *iface, boolean *result)
 {
+    struct core_input_view *impl = impl_from_ICoreInputView(iface);
+
     FIXME("iface %p, boolean %p semi-stub!\n", iface, result);
+
+    if (impl->tabtip_hwnd)
+        PostMessageW(impl->tabtip_hwnd, WM_TABTIP_OSK_TOGGLE, FALSE, 0);
 
     *result = TRUE;
     return S_OK;
@@ -253,7 +266,12 @@ DEFINE_IINSPECTABLE(core_input_view3, ICoreInputView3, struct core_input_view, I
 
 static HRESULT WINAPI core_input_view3_TryShow(ICoreInputView3 *iface, boolean *result)
 {
+    struct core_input_view *impl = impl_from_ICoreInputView3(iface);
+
     FIXME("iface %p, result %p semi-stub!\n", iface, result);
+
+    if (impl->tabtip_hwnd)
+        PostMessageW(impl->tabtip_hwnd, WM_TABTIP_OSK_TOGGLE, TRUE, 0);
 
     *result = FALSE;
     return S_OK;
@@ -263,7 +281,12 @@ static HRESULT WINAPI core_input_view3_TryShowWithKind(ICoreInputView3 *iface,
                                                        CoreInputViewKind type,
                                                        boolean *result)
 {
+    struct core_input_view *impl = impl_from_ICoreInputView3(iface);
+
     FIXME("iface %p, type %d, result %p semi-stub!\n", iface, type, result);
+
+    if (impl->tabtip_hwnd && (type == CoreInputViewKind_Default || type == CoreInputViewKind_Keyboard))
+        PostMessageW(impl->tabtip_hwnd, WM_TABTIP_OSK_TOGGLE, TRUE, 0);
 
     *result = FALSE;
     return S_OK;
@@ -271,7 +294,12 @@ static HRESULT WINAPI core_input_view3_TryShowWithKind(ICoreInputView3 *iface,
 
 static HRESULT WINAPI core_input_view3_TryHide(ICoreInputView3 *iface, boolean *result)
 {
+    struct core_input_view *impl = impl_from_ICoreInputView3(iface);
+
     FIXME("iface %p, result %p semi-stub!\n", iface, result);
+
+    if (impl->tabtip_hwnd)
+        PostMessageW(impl->tabtip_hwnd, WM_TABTIP_OSK_TOGGLE, FALSE, 0);
 
     *result = TRUE;
     return S_OK;
@@ -453,6 +481,7 @@ static HRESULT WINAPI core_input_view_statics_GetForCurrentView(ICoreInputViewSt
     view->ICoreInputView2_iface.lpVtbl = &core_input_view2_vtbl;
     view->ICoreInputView3_iface.lpVtbl = &core_input_view3_vtbl;
     view->ICoreInputView4_iface.lpVtbl = &core_input_view4_vtbl;
+    view->tabtip_hwnd = FindWindowW(L"IPTip_Main_Window", L"Input");
 
     if (FAILED(hr = weak_reference_source_init(&view->weak_reference_source,
                                                (IUnknown *)&view->ICoreInputView_iface)))

--- a/dlls/windows.ui.core.textinput/main.c
+++ b/dlls/windows.ui.core.textinput/main.c
@@ -159,14 +159,18 @@ static HRESULT WINAPI core_input_view_GetCoreInputViewOcclusions(ICoreInputView 
 
 static HRESULT WINAPI core_input_view_TryShowPrimaryView(ICoreInputView *iface, boolean *result)
 {
-    FIXME("iface %p, boolean %p stub!\n", iface, result);
-    return E_NOTIMPL;
+    FIXME("iface %p, boolean %p semi-stub!\n", iface, result);
+
+    *result = FALSE;
+    return S_OK;
 }
 
 static HRESULT WINAPI core_input_view_TryHidePrimaryView(ICoreInputView *iface, boolean *result)
 {
-    FIXME("iface %p, boolean %p stub!\n", iface, result);
-    return E_NOTIMPL;
+    FIXME("iface %p, boolean %p semi-stub!\n", iface, result);
+
+    *result = TRUE;
+    return S_OK;
 }
 
 static const struct ICoreInputViewVtbl core_input_view_vtbl =
@@ -249,22 +253,28 @@ DEFINE_IINSPECTABLE(core_input_view3, ICoreInputView3, struct core_input_view, I
 
 static HRESULT WINAPI core_input_view3_TryShow(ICoreInputView3 *iface, boolean *result)
 {
-    FIXME("iface %p, result %p stub!\n", iface, result);
-    return E_NOTIMPL;
+    FIXME("iface %p, result %p semi-stub!\n", iface, result);
+
+    *result = FALSE;
+    return S_OK;
 }
 
 static HRESULT WINAPI core_input_view3_TryShowWithKind(ICoreInputView3 *iface,
                                                        CoreInputViewKind type,
                                                        boolean *result)
 {
-    FIXME("iface %p, type %d, result %p stub!\n", iface, type, result);
-    return E_NOTIMPL;
+    FIXME("iface %p, type %d, result %p semi-stub!\n", iface, type, result);
+
+    *result = FALSE;
+    return S_OK;
 }
 
 static HRESULT WINAPI core_input_view3_TryHide(ICoreInputView3 *iface, boolean *result)
 {
-    FIXME("iface %p, result %p stub!\n", iface, result);
-    return E_NOTIMPL;
+    FIXME("iface %p, result %p semi-stub!\n", iface, result);
+
+    *result = TRUE;
+    return S_OK;
 }
 
 static const struct ICoreInputView3Vtbl core_input_view3_vtbl =

--- a/dlls/windows.ui.core.textinput/private.h
+++ b/dlls/windows.ui.core.textinput/private.h
@@ -23,6 +23,7 @@
 #define COBJMACROS
 #include "windef.h"
 #include "winbase.h"
+#include "winuser.h"
 #include "winstring.h"
 #include "activation.h"
 #include "wine/debug.h"


### PR DESCRIPTION
### Problem

Unity 6 titles (e.g. Albion Online, appid 761890) crash the moment a text field is committed (pressing Enter in chat, market search, etc.). The engine calls `CoreInputView.GetForCurrentView().TryHide()`; the stubs in `windows.ui.core.textinput` return `E_NOTIMPL`, which the C++/WinRT projection turns into an unhandled `hresult_not_implemented` exception:

```
fixme:coreinputview:core_input_view3_TryHide iface ..., result ... stub!
fixme:combase:RoOriginateLanguageException 0x80004001
trace:seh:dispatch_exception code=e06d7363 (EXCEPTION_WINE_CXX_EXCEPTION)
wine: Unhandled exception 0xe06d7363 ...
```

Disabling the DLL does not help either the activation failure takes the same unhandled-exception path. On Windows this API always exists and succeeds, so games have no reason to handle failure.

### Fix

1. Return success from the `TryShow*`/`TryHide*` methods: `TryShow*` reports `FALSE` (no pane was shown), `TryHide*` reports `TRUE` (nothing is shown, so it is hidden) same convention as `inputpane2_TryShow` in `windows.ui`.
2. Forward the calls to the tabtip window (`WM_TABTIP_OSK_TOGGLE`), mirroring the existing `InputPane` implementation, so the Steam on-screen keyboard follows text-field focus in CoreInputView-based titles. `TryShowWithKind` only toggles the keyboard for the `Default` and `Keyboard` kinds.

### Testing

Tested with Albion Online on Arch/Hyprland: without the patch the client crashes on every text-field commit; with it chat and market search work.
The OSK toggling follows the same mechanism as the existing InputPane implementation.