### PR TITLE
winmm: Open mmio files using the Unicode file APIs

### DIFF
--- a/dlls/winmm/mmio.c
+++ b/dlls/winmm/mmio.c
@@ -54,8 +54,9 @@ static WINE_MMIO *MMIOList;
 /* From kernel32 */
 static HANDLE create_file_OF( LPCSTR path, INT mode )
 {
-    DWORD access, sharing, creation;
-    char full_path[MAX_PATH];
+    DWORD access, sharing, creation, len;
+    WCHAR *pathW, full_path[MAX_PATH];
+    HANDLE ret;
 
     if (mode & OF_CREATE)
     {
@@ -84,12 +85,25 @@ static HANDLE create_file_OF( LPCSTR path, INT mode )
     default:                  sharing = FILE_SHARE_READ | FILE_SHARE_WRITE; break;
     }
 
-    if (mode & OF_CREATE)
-        return CreateFileA( path, access, sharing, NULL, creation, FILE_ATTRIBUTE_NORMAL, 0 );
-
-    if (!SearchPathA( NULL, path, NULL, MAX_PATH, full_path, NULL ))
+    if (!(len = MultiByteToWideChar( CP_ACP, 0, path, -1, NULL, 0 )))
         return INVALID_HANDLE_VALUE;
-    return CreateFileA( full_path, access, sharing, NULL, creation, FILE_ATTRIBUTE_NORMAL, 0 );
+    if (!(pathW = malloc( len * sizeof(*pathW) )))
+        return INVALID_HANDLE_VALUE;
+    MultiByteToWideChar( CP_ACP, 0, path, -1, pathW, len );
+
+    /* Use the Unicode APIs: the path SearchPathA() resolves may contain
+     * characters that cannot be represented in the ANSI codepage, which it
+     * would silently replace with '?'.
+     */
+    if (mode & OF_CREATE)
+        ret = CreateFileW( pathW, access, sharing, NULL, creation, FILE_ATTRIBUTE_NORMAL, 0 );
+    else if (!SearchPathW( NULL, pathW, NULL, ARRAY_SIZE(full_path), full_path, NULL ))
+        ret = INVALID_HANDLE_VALUE;
+    else
+        ret = CreateFileW( full_path, access, sharing, NULL, creation, FILE_ATTRIBUTE_NORMAL, 0 );
+
+    free( pathW );
+    return ret;
 }
 
 /**************************************************************************

--- a/dlls/winmm/tests/mmio.c
+++ b/dlls/winmm/tests/mmio.c
@@ -23,6 +23,7 @@
 #include "windef.h"
 #include "winbase.h"
 #include "wingdi.h"
+#include "winnls.h"
 #include "mmsystem.h"
 #include "vfw.h"
 #include "wine/test.h"
@@ -585,6 +586,89 @@ static void test_mmioOpen_create(void)
     ok(ret, "got error %lu\n", GetLastError());
 }
 
+static void test_mmioOpen_unicode_path(void)
+{
+    /* Characters from a few different scripts, so that at least one of them is
+     * not representable in whichever ANSI codepage the tests are run under.
+     */
+    static const WCHAR candidates[] = {0x4e2d, 0x0416, 0x05d0, 0x0e01, 0x2603};
+    WCHAR dir_name[MAX_PATH], cwd[MAX_PATH], temp_dir[MAX_PATH], name[MAX_PATH];
+    WCHAR wc = 0;
+    MMIOINFO info = {0};
+    HANDLE file;
+    HMMIO hmmio;
+    unsigned int i;
+    BOOL used, ret;
+    char buffer[8];
+    size_t len;
+
+    if (GetACP() == CP_UTF8)
+    {
+        skip("every character is representable in codepage %u\n", GetACP());
+        return;
+    }
+
+    for (i = 0; i < ARRAY_SIZE(candidates); i++)
+    {
+        used = FALSE;
+        WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, &candidates[i], 1,
+                buffer, sizeof(buffer), NULL, &used);
+        if (used)
+        {
+            wc = candidates[i];
+            break;
+        }
+    }
+    if (!wc)
+    {
+        skip("no character outside of codepage %u available\n", GetACP());
+        return;
+    }
+
+    GetCurrentDirectoryW(ARRAY_SIZE(cwd), cwd);
+    GetTempPathW(ARRAY_SIZE(temp_dir), temp_dir);
+
+    wcscpy(dir_name, temp_dir);
+    wcscat(dir_name, L"wine_mmio_");
+    len = wcslen(dir_name);
+    dir_name[len] = wc;
+    dir_name[len + 1] = 0;
+
+    /* clean up after a previous aborted run */
+    wcscpy(name, dir_name);
+    wcscat(name, L"\\test_mmio_path");
+    DeleteFileW(name);
+    RemoveDirectoryW(dir_name);
+
+    ret = CreateDirectoryW(dir_name, NULL);
+    ok(ret, "failed to create %s, error %lu\n", debugstr_w(dir_name), GetLastError());
+    SetCurrentDirectoryW(dir_name);
+
+    file = CreateFileW(L"test_mmio_path", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL, NULL);
+    ok(file != INVALID_HANDLE_VALUE, "got error %lu\n", GetLastError());
+    CloseHandle(file);
+
+    /* A relative name is resolved against the current directory, whose name
+     * cannot be represented in the ANSI codepage here. The name itself is
+     * plain ASCII, so this has to work regardless of the codepage.
+     */
+    wcscpy(name, L"test_mmio_path");
+    info.wErrorRet = 0xdead;
+    hmmio = mmioOpenW(name, &info, MMIO_ALLOCBUF | MMIO_DENYWRITE | MMIO_READ);
+    ok(!!hmmio, "failed to open file, error %#x\n", info.wErrorRet);
+    if (hmmio)
+        mmioClose(hmmio, 0);
+
+    ret = DeleteFileW(L"test_mmio_path");
+    ok(ret, "got error %lu\n", GetLastError());
+
+    SetCurrentDirectoryW(cwd);
+
+    ret = RemoveDirectoryW(dir_name);
+    ok(ret, "got error %lu\n", GetLastError());
+}
+
 static void test_mmioSetBuffer(char *fname)
 {
     char buf[256];
@@ -1133,6 +1217,7 @@ START_TEST(mmio)
     test_mmioOpen(NULL);
     test_mmioOpen(fname);
     test_mmioOpen_create();
+    test_mmioOpen_unicode_path();
     test_mmioSetBuffer(NULL);
     test_mmioSetBuffer(fname);
     test_mmioOpen_fourcc();


### PR DESCRIPTION
Sound effects are completely silent in Steam app 2006210 (血染め鬼女) under Proton: every `mciSendString("open \"data/datN.w\" alias OTON.M type waveaudio")` fails with `MCIERR_FILE_NOT_FOUND` (172 of them at startup), while the MP3 music — `type MPEGVideo` → `mciqtz32` → `quartz` — plays normally.

### Cause

- `mciwave` opens files with `mmioOpenW()`, whose only file primitive is winmm's `create_file_OF()`.
- `create_file_OF()` resolved relative names with `SearchPathA()`, which is `SearchPathW()` followed by a lossy `RtlUnicodeStringToAnsiString()` of the **result**.
- The game's install directory is named `血染め鬼女`, which is not representable in the prefix's ANSI codepage (1252 here), so the correctly-resolved absolute path came back as `?????` and `CreateFileA()` failed with `ERROR_INVALID_NAME`.
- `mmio` maps any open failure to `MMIOERR_FILENOTFOUND`, which `mciwave` then reports as `can't find file` — misleading, since the file is present and readable.

Visible directly in a `+mmio,+file` trace, where `SearchPathW` succeeds and `CreateFileA` is handed the mangled result:

```
trace:file:SearchPathW found L"Z:\\...\\common\\\8840\67d3\3081\9b3c\5973\\data\\dat1.w"
trace:file:CreateFileW L"Z:\\...\\common\\?????\\data\\dat1.w" GENERIC_READ FILE_SHARE_READ creation 3
warn:file:NtCreateFile L"\\??\\Z:\\...\\common\\?????\\data\\dat1.w" not found (c0000033)
```

The filename the application passes is plain ASCII (`data/dat9.w`); only the *resolved* path cannot survive the round trip. `mciqtz32`/`quartz` are unaffected because they use `CreateFileW` and never touch `mmio`.

### Scope

- Non-ASCII **filenames** passed to `mmioOpenW()` are still mangled, by the `CP_ACP` conversion at the top of `mmioOpenW()` itself. Fixing that means plumbing WCHAR through `MMIO_Open()`/`mmioDosIOProc()`, which changes what custom ANSI IOProcs registered via `mmioInstallIOProcA()` receive. Deliberately not attempted here.
- The heap buffer rather than a fixed one is to avoid introducing a `MAX_PATH` limit on the `OF_CREATE` branch, which previously passed `path` straight to `CreateFileA()` unbounded.

### Testing

- New `winmm:mmio` test creates a directory whose name is outside the current ANSI codepage, chdirs into it, and opens a plain-ASCII relative filename with the same flags `mciwave` uses (`MMIO_ALLOCBUF | MMIO_DENYWRITE | MMIO_READ`). It fails with `0x101` (`MMIOERR_FILENOTFOUND`) before this change and passes after.
- The test picks its character from several scripts and skips when the ANSI codepage can represent all of them (or is UTF-8), so it is a no-op rather than a false failure under e.g. a Japanese locale.
- Ran `winmm:mmio`, `mci`, `wave`, `timer`, `mixer`. `mmio` goes FAIL → PASS; the other four are unchanged — `mci` has 73 pre-existing failures in this headless environment, identical with and without the patch.
- Also confirmed against a stock vs. patched Proton Experimental build (x86_64), same prefix layout and same test: stock fails with `0x101`, patched passes.
- **Verified in-game**: with a Proton Experimental build carrying only this patch, and no locale workaround, the game's sound effects work.
- Built and tested on the `proton_11.0` tree; `dlls/winmm/mmio.c` and `dlls/winmm/tests/mmio.c` are byte-identical between `proton_11.0` and `bleeding-edge`, so the change applies unmodified here.
- **Not verified against Windows**: I have no Windows machine. The test asserts the behaviour I believe native has (`mmioOpenW` being genuinely Unicode-capable for the default file IOProc). If native turns out to fail the same way, the new assertion should become `todo_wine` and this would be a bug-compatibility question rather than a fix.

Without this patch the only workaround is forcing an ANSI codepage that can encode the install path (`HOST_LC_ALL=ja_JP.UTF-8`), which is not something a user should have to discover.

Submitted upstream as https://gitlab.winehq.org/wine/wine/-/merge_requests/11606 — same two commits, cherry-picked onto wine master (the only difference between the two bases in these files is the Proton-only `#define WIN32_NO_STATUS` in `mmio.c`, which is nowhere near the change). If it lands upstream this PR can simply be closed in favour of the merge.
