### PR TITLE
macOS Rosetta 2 compatibility and build fixes

### DIFF
--- a/dlls/amd_ags_x64/unixlib.c
+++ b/dlls/amd_ags_x64/unixlib.c
@@ -31,9 +31,11 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#include <xf86drm.h>
-#include <amdgpu_drm.h>
-#include <amdgpu.h>
+#ifdef __linux__
+# include <xf86drm.h>
+# include <amdgpu_drm.h>
+# include <amdgpu.h>
+#endif
 
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
@@ -45,6 +47,8 @@
 #include "unixlib.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(amd_ags);
+
+#ifdef __linux__
 
 #define MAX_DEVICE_COUNT 64
 
@@ -275,6 +279,21 @@ static NTSTATUS get_device_info( void *args )
     TRACE("Device %04x not found.\n", params->device_id);
     return STATUS_NOT_FOUND;
 }
+
+#else
+
+static NTSTATUS init( void *args )
+{
+    WARN("AMD AGS device discovery requires the Linux DRM subsystem.\n");
+    return STATUS_NOT_SUPPORTED;
+}
+
+static NTSTATUS get_device_info( void *args )
+{
+    return STATUS_NOT_FOUND;
+}
+
+#endif
 
 const unixlib_entry_t __wine_unix_call_funcs[] =
 {

--- a/dlls/ntdll/unix/fsync.c
+++ b/dlls/ntdll/unix/fsync.c
@@ -141,15 +141,25 @@ static void simulate_sched_quantum(void)
 static inline int futex_wait_multiple( const struct futex_waitv *futexes,
         int count, const struct timespec64 *end, clockid_t clock_id )
 {
+#ifdef __linux__
    if (end)
         return syscall( __NR_futex_waitv, futexes, count, 0, end, clock_id );
    else
         return syscall( __NR_futex_waitv, futexes, count, 0, NULL, 0 );
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
 }
 
 static inline int futex_wake( int *addr, int val )
 {
+#ifdef __linux__
     return syscall( __NR_futex, addr, 1, val, NULL, 0, 0 );
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
 }
 
 struct fsync
@@ -455,6 +465,11 @@ void fsync_init( DWORD pid )
     struct stat st;
 
 
+#ifndef __linux__
+    ERR("WINEFSYNC is not supported on this platform.\n");
+    fsync_enabled = 0;
+    return;
+#else
     fsync_enabled = 1;
     syscall( __NR_futex_waitv, NULL, 0, 0, NULL, 0 );
     if (errno == ENOSYS || errno == EPERM)
@@ -462,6 +477,7 @@ void fsync_init( DWORD pid )
         ERR("Server is running with WINEFSYNC but this process can't use __NR_futex_waitv.\n");
         exit(1);
     }
+#endif
 
     if (stat( config_dir, &st ) == -1)
         ERR("Cannot stat %s\n", config_dir);

--- a/dlls/ntdll/unix/loader.c
+++ b/dlls/ntdll/unix/loader.c
@@ -2610,9 +2610,41 @@ static void apple_create_wine_thread( void *arg )
 {
     pthread_t thread;
     pthread_attr_t attr;
+    void *stack;
+    size_t stack_size = 8 * 1024 * 1024;  /* 8 MB, same as macOS default */
 
     pthread_attr_init( &attr );
     pthread_attr_setdetachstate( &attr, PTHREAD_CREATE_JOINABLE );
+
+    /* The Mach-O .zerofill WINE_RESERVE segment spans 0x1000–0x200000000 (low 8 GB).
+     * macOS places secondary pthread stacks inside that range by default (typically
+     * around 0x7fde0000), which are then PROT_NONE due to the zerofill mapping.
+     * When the wine thread writes to deep stack frames it hits KERN_PROTECTION_FAILURE / SIGBUS.
+     *
+     * Fix: allocate the stack explicitly above 0x200000000 with MAP_FIXED_NOREPLACE
+     * so it lands outside WINE_RESERVE, and hand it to pthread via pthread_attr_setstack.
+     *
+     * Try addresses from 0x200100000 upward in 8 MB steps until mmap succeeds.
+     */
+    stack = MAP_FAILED;
+    {
+        uintptr_t addr = 0x200100000ul;  /* just above WINE_RESERVE end (0x200000000) */
+        int tries;
+        for (tries = 0; tries < 64 && stack == MAP_FAILED; tries++, addr += stack_size)
+        {
+#ifdef MAP_FIXED_NOREPLACE
+            stack = mmap( (void *)addr, stack_size, PROT_READ | PROT_WRITE,
+                          MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANON, -1, 0 );
+#else
+            stack = mmap( (void *)addr, stack_size, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANON, -1, 0 );
+#endif
+        }
+    }
+
+    if (stack != MAP_FAILED)
+        pthread_attr_setstack( &attr, stack, stack_size );
+
     if (pthread_create( &thread, &attr, apple_wine_thread, NULL )) exit(1);
     pthread_attr_destroy( &attr );
 }

--- a/dlls/ntdll/unix/loader.c
+++ b/dlls/ntdll/unix/loader.c
@@ -38,7 +38,9 @@
 #include <sys/mman.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <malloc.h>
+#ifdef __GLIBC__
+# include <malloc.h>
+#endif
 #include <dlfcn.h>
 #ifdef HAVE_PWD_H
 # include <pwd.h>
@@ -2450,7 +2452,9 @@ static void start_main_thread(void)
     set_thread_teb( teb );
 #endif
 
+#ifdef M_PERTURB
     mallopt( M_PERTURB, 0xff );
+#endif
     init_startup_info();
     *(ULONG_PTR *)&peb->CloudFileFlags = get_image_address();
     set_load_order_app_name( main_wargv[0] );
@@ -2459,7 +2463,9 @@ static void start_main_thread(void)
     load_ntdll();
     load_wow64_ntdll( main_image_info.Machine );
     load_apiset_dll();
+#ifdef M_PERTURB
     mallopt( M_PERTURB, 0 );
+#endif
     server_init_process_done();
 }
 

--- a/dlls/ntdll/unix/ntsync_tmp.h
+++ b/dlls/ntdll/unix/ntsync_tmp.h
@@ -8,7 +8,17 @@
 #ifndef __LINUX_NTSYNC_H
 #define __LINUX_NTSYNC_H
 
+#include <sys/ioctl.h>
+
+#ifdef HAVE_LINUX_TYPES_H
 #include <linux/types.h>
+#elif defined(__linux__)
+#include <linux/types.h>
+#else
+#include <stdint.h>
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+#endif
 
 struct ntsync_sem_args {
 	__u32 count;

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -3372,6 +3372,7 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "popq 0x80(%rcx)\n\t"
                    __ASM_CFI(".cfi_adjust_cfa_offset -8\n\t")
                    "movl $0,0xb4(%rcx)\n\t"        /* frame->restore_flags */
+                   "movq %gs:0x30,%r13\n\t"        /* teb */
                    __ASM_LOCAL_LABEL("__wine_syscall_dispatcher_prolog_end") ":\n\t"
                    "movq %rbx,0x08(%rcx)\n\t"
                    __ASM_CFI_REG_IS_AT1(rbx, rcx, 0x08)
@@ -3394,9 +3395,6 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "movw %ss,0x90(%rcx)\n\t"
                    "movq %rbp,0x98(%rcx)\n\t"
                    __ASM_CFI_REG_IS_AT2(rbp, rcx, 0x98, 0x01)
-#ifndef __APPLE__
-                   "movq %gs:0x30,%r13\n\t"        /* teb */
-#endif
                    "movl %eax,0xb0(%rcx)\n\t"      /* frame->syscall_id */
                    /* Legends of Runeterra hooks the first system call return instruction, and
                     * depends on us returning to it. Adjust the return address accordingly. */

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -1842,8 +1842,7 @@ __ASM_GLOBAL_FUNC( call_user_mode_callback,
                    "movq %rcx,%r10\n\t"
                    "movq %r13,%rdi\n\t"
                    "xorl %esi,%esi\n\t"
-                   "movl $0x3000003,%eax\n\t"  /* _thread_set_tsd_base */
-                   "syscall\n\t"
+                   "call _thread_set_tsd_base\n\t"
                    "movq %r10,%rcx\n\t"
 #endif
                    "movq 0x330(%r13),%r10\n\t" /* amd64_thread_data()->instrumentation_callback */
@@ -3461,8 +3460,7 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
 #elif defined __APPLE__
                    "movq 0x320(%r13),%rdi\n\t"     /* amd64_thread_data()->pthread_teb */
                    "xorl %esi,%esi\n\t"
-                   "movl $0x3000003,%eax\n\t"      /* _thread_set_tsd_base */
-                   "syscall\n\t"
+                   "call _thread_set_tsd_base\n\t"
                    "leaq -0x98(%rbp),%rcx\n"
 #endif
                    "ldmxcsr 0x33c(%r13)\n\t"       /* amd64_thread_data()->mxcsr */
@@ -3515,8 +3513,7 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "movq %rcx,%rdx\n\t"
                    "movq %r13,%rdi\n\t"            /* teb */
                    "xorl %esi,%esi\n\t"
-                   "movl $0x3000003,%eax\n\t"      /* _thread_set_tsd_base */
-                   "syscall\n\t"
+                   "call _thread_set_tsd_base\n\t"
                    "movq %rdx,%rcx\n\t"
                    "movq %r8,%rax\n\t"
 #endif
@@ -3749,8 +3746,7 @@ __ASM_GLOBAL_FUNC( __wine_unix_call_dispatcher,
 #elif defined __APPLE__
                    "movq 0x320(%r13),%rdi\n\t"     /* amd64_thread_data()->pthread_teb */
                    "xorl %esi,%esi\n\t"
-                   "movl $0x3000003,%eax\n\t"      /* _thread_set_tsd_base */
-                   "syscall\n\t"
+                   "call _thread_set_tsd_base\n\t"
 #endif
                    "ldmxcsr 0x33c(%r13)\n\t"       /* amd64_thread_data()->mxcsr */
                    "movq %r8,%rdi\n\t"             /* args */
@@ -3783,8 +3779,7 @@ __ASM_GLOBAL_FUNC( __wine_unix_call_dispatcher,
                    "movq %rcx,%r14\n\t"
                    "movq %r13,%rdi\n\t"            /* teb */
                    "xorl %esi,%esi\n\t"
-                   "movl $0x3000003,%eax\n\t"      /* _thread_set_tsd_base */
-                   "syscall\n\t"
+                   "call _thread_set_tsd_base\n\t"
                    "movq %r14,%rcx\n\t"
                    "movq %rdx,%rax\n\t"
                    "movq 0x60(%rcx),%r14\n\t"

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -1839,11 +1839,13 @@ __ASM_GLOBAL_FUNC( call_user_mode_callback,
                    "movw %ax,%fs\n"
                    "1:\n\t"
 #elif defined __APPLE__
-                   "movq %rcx,%r10\n\t"
+                   "pushq %rcx\n\t"
+                   "subq $8,%rsp\n\t"
                    "movq %r13,%rdi\n\t"
                    "xorl %esi,%esi\n\t"
-                   "call _thread_set_tsd_base\n\t"
-                   "movq %r10,%rcx\n\t"
+                   "call " __ASM_NAME("_thread_set_tsd_base") "\n\t"
+                   "addq $8,%rsp\n\t"
+                   "popq %rcx\n\t"
 #endif
                    "movq 0x330(%r13),%r10\n\t" /* amd64_thread_data()->instrumentation_callback */
                    "movq (%r10),%r10\n\t"
@@ -2997,6 +2999,7 @@ static void sigsys_handler( int signal, siginfo_t *siginfo, void *sigcontext )
     extern const void *__wine_syscall_dispatcher_prolog_end_ptr;
     ucontext_t *ucontext = init_handler( sigcontext );
     struct syscall_frame *frame = get_syscall_frame();
+    TEB *teb = NtCurrentTeb();
 
     TRACE_(seh)("SIGSYS, rax %#llx, rip %#llx.\n", RAX_sig(ucontext), RIP_sig(ucontext));
 
@@ -3006,6 +3009,7 @@ static void sigsys_handler( int signal, siginfo_t *siginfo, void *sigcontext )
     frame->restore_flags = 0;
     if (instrumentation_callback) frame->restore_flags |= RESTORE_FLAGS_INSTRUMENTATION;
     RCX_sig(ucontext) = (ULONG_PTR)frame;
+    R13_sig(ucontext) = (ULONG_PTR)teb;
     R11_sig(ucontext) = frame->eflags;
     if (EFL_sig(ucontext) & 0x100)
     {
@@ -3203,7 +3207,10 @@ void set_thread_teb( TEB *teb )
 #elif defined(__NetBSD__)
     sysarch( X86_64_SET_GSBASE, &teb );
 #elif defined (__APPLE__)
-    _thread_set_tsd_base( (uint64_t)teb );
+    /* On macOS x86_64, %gs is used for pthread TSD. Setting TEB here would corrupt
+     * pthread TLS while Unix initialization code runs. The transition to Windows
+     * code in signal_start_thread / __wine_syscall_dispatcher_return handles setting
+     * TSD base to TEB. */
 #else
 # error Please define setting %gs for your architecture
 #endif
@@ -3387,7 +3394,9 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "movw %ss,0x90(%rcx)\n\t"
                    "movq %rbp,0x98(%rcx)\n\t"
                    __ASM_CFI_REG_IS_AT2(rbp, rcx, 0x98, 0x01)
+#ifndef __APPLE__
                    "movq %gs:0x30,%r13\n\t"        /* teb */
+#endif
                    "movl %eax,0xb0(%rcx)\n\t"      /* frame->syscall_id */
                    /* Legends of Runeterra hooks the first system call return instruction, and
                     * depends on us returning to it. Adjust the return address accordingly. */
@@ -3458,10 +3467,17 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "leaq -0x98(%rbp),%rcx\n"
                    "2:\n\t"
 #elif defined __APPLE__
+                   "pushq %r10\n\t"
+                   "pushq %r8\n\t"
+                   "pushq %r9\n\t"
+                   "pushq %rcx\n\t"
                    "movq 0x320(%r13),%rdi\n\t"     /* amd64_thread_data()->pthread_teb */
                    "xorl %esi,%esi\n\t"
-                   "call _thread_set_tsd_base\n\t"
-                   "leaq -0x98(%rbp),%rcx\n"
+                   "call " __ASM_NAME("_thread_set_tsd_base") "\n\t"
+                   "popq %rcx\n\t"
+                   "popq %r9\n\t"
+                   "popq %r8\n\t"
+                   "popq %r10\n\t"
 #endif
                    "ldmxcsr 0x33c(%r13)\n\t"       /* amd64_thread_data()->mxcsr */
                    "movl 0xb0(%rcx),%eax\n\t"      /* frame->syscall_id */
@@ -3509,13 +3525,13 @@ __ASM_GLOBAL_FUNC( __wine_syscall_dispatcher,
                    "movw %dx,%fs\n"
                    "1:\n\t"
 #elif defined __APPLE__
-                   "movq %rax,%r8\n\t"
-                   "movq %rcx,%rdx\n\t"
+                   "pushq %rcx\n\t"
+                   "pushq %rax\n\t"
                    "movq %r13,%rdi\n\t"            /* teb */
                    "xorl %esi,%esi\n\t"
-                   "call _thread_set_tsd_base\n\t"
-                   "movq %rdx,%rcx\n\t"
-                   "movq %r8,%rax\n\t"
+                   "call " __ASM_NAME("_thread_set_tsd_base") "\n\t"
+                   "popq %rax\n\t"
+                   "popq %rcx\n\t"
 #endif
                    "movl 0xb4(%rcx),%edx\n\t"      /* frame->restore_flags */
                    "testl $0x48,%edx\n\t"          /* CONTEXT_FLOATING_POINT | CONTEXT_XSTATE */
@@ -3744,9 +3760,17 @@ __ASM_GLOBAL_FUNC( __wine_unix_call_dispatcher,
                    "syscall\n\t"
                    "2:\n\t"
 #elif defined __APPLE__
+                   "pushq %r10\n\t"
+                   "pushq %rdx\n\t"
+                   "pushq %r8\n\t"
+                   "subq $8,%rsp\n\t"
                    "movq 0x320(%r13),%rdi\n\t"     /* amd64_thread_data()->pthread_teb */
                    "xorl %esi,%esi\n\t"
-                   "call _thread_set_tsd_base\n\t"
+                   "call " __ASM_NAME("_thread_set_tsd_base") "\n\t"
+                   "addq $8,%rsp\n\t"
+                   "popq %r8\n\t"
+                   "popq %rdx\n\t"
+                   "popq %r10\n\t"
 #endif
                    "ldmxcsr 0x33c(%r13)\n\t"       /* amd64_thread_data()->mxcsr */
                    "movq %r8,%rdi\n\t"             /* args */
@@ -3775,14 +3799,13 @@ __ASM_GLOBAL_FUNC( __wine_unix_call_dispatcher,
                    "movw %dx,%fs\n"
                    "1:\n\t"
 #elif defined __APPLE__
-                   "movq %rax,%rdx\n\t"
-                   "movq %rcx,%r14\n\t"
+                   "pushq %rax\n\t"
+                   "pushq %rcx\n\t"
                    "movq %r13,%rdi\n\t"            /* teb */
                    "xorl %esi,%esi\n\t"
-                   "call _thread_set_tsd_base\n\t"
-                   "movq %r14,%rcx\n\t"
-                   "movq %rdx,%rax\n\t"
-                   "movq 0x60(%rcx),%r14\n\t"
+                   "call " __ASM_NAME("_thread_set_tsd_base") "\n\t"
+                   "popq %rcx\n\t"
+                   "popq %rax\n\t"
 #endif
                    "movq 0x58(%rcx),%r13\n\t"
                    "movq 0x28(%rcx),%rdi\n\t"

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -2279,7 +2279,7 @@ __ASM_GLOBAL_FUNC( dump_syscall_fault_return,
                    "movq %rdi,%rsp\n\t"
                    "movq %rsi,%rax\n\t"
                    "movq %rdx,%r13\n\t"
-                   "jmp %rcx")
+                   "jmpq *%rcx")
 
 
 static void dump_syscall_fault( CONTEXT *context, DWORD exc_code )
@@ -3197,7 +3197,17 @@ void signal_init_process(void)
 
 void set_thread_teb( TEB *teb )
 {
+#if defined __linux__
     arch_prctl( ARCH_SET_GS, teb );
+#elif defined (__FreeBSD__) || defined (__FreeBSD_kernel__)
+    amd64_set_gsbase( teb );
+#elif defined(__NetBSD__)
+    sysarch( X86_64_SET_GSBASE, &teb );
+#elif defined (__APPLE__)
+    _thread_set_tsd_base( (uint64_t)teb );
+#else
+# error Please define setting %gs for your architecture
+#endif
 }
 
 /***********************************************************************

--- a/dlls/ntdll/unix/sync.c
+++ b/dlls/ntdll/unix/sync.c
@@ -61,7 +61,9 @@
 # include <sys/event.h>
 #endif
 
+#ifdef __linux__
 # include "ntsync_tmp.h"
+#endif
 
 #include "ntstatus.h"
 #define WIN32_NO_STATUS

--- a/dlls/ntdll/unix/system.c
+++ b/dlls/ntdll/unix/system.c
@@ -765,8 +765,10 @@ void init_shared_data_cpuinfo( KUSER_SHARED_DATA *data )
 
 #endif /* End architecture specific feature detection for CPUs */
 
+#ifdef __linux__
 static void fill_performance_core_info(void);
 static BOOL sysfs_parse_bitmap(const char *filename, ULONG_PTR *mask);
+#endif
 
 void fill_cpu_override(void)
 {
@@ -832,8 +834,8 @@ void fill_cpu_override(void)
             return;
         }
 
+#ifdef __linux__
         fill_performance_core_info();
-
         for (i = 0; i < host_cpu_count; ++i)
         {
             snprintf(name, sizeof(name), core_info, i, "thread_siblings");
@@ -866,6 +868,13 @@ skip_cpu:
             if (count == cpu_override.mapping.cpu_count) break;
         }
         assert( count == cpu_override.mapping.cpu_count );
+#else
+        for (i = 0; i < cpu_override.mapping.cpu_count; ++i)
+        {
+            cpu_override.mapping.host_cpu_id[i] = i;
+            cpu_override.siblings_mask[i] = (ULONG_PTR)1 << i;
+        }
+#endif
         goto done;
     }
 

--- a/dlls/win32u/opengl.c
+++ b/dlls/win32u/opengl.c
@@ -1569,6 +1569,29 @@ static void init_egl_platforms( struct opengl_funcs *funcs, const struct opengl_
 {
 }
 
+static BOOL needs_framebuffer_surface( HWND hwnd )
+{
+    return FALSE;
+}
+
+static const struct opengl_drawable_funcs framebuffer_surface_funcs;
+
+struct framebuffer_surface
+{
+    struct opengl_drawable base;
+    struct opengl_drawable *target;
+};
+
+static inline struct framebuffer_surface *framebuffer_from_opengl_drawable( struct opengl_drawable *base )
+{
+    return NULL;
+}
+
+static inline struct opengl_drawable *framebuffer_surface_create( int format, struct client_surface *client, struct opengl_drawable *target )
+{
+    return NULL;
+}
+
 #endif /* SONAME_LIBEGL */
 
 static UINT read_drm_device_prop( const char *name, const char *prop )

--- a/dlls/winegstreamer/media-converter/media-converter.h
+++ b/dlls/winegstreamer/media-converter/media-converter.h
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <pthread.h>
 
 #include "unix_private.h"
 #include "wine/rbtree.h"

--- a/loader/main.c
+++ b/loader/main.c
@@ -64,14 +64,10 @@ const __attribute((visibility("default"))) struct wine_preload_info *wine_main_p
 
 static void init_reserved_areas(void)
 {
-    int i;
-
-    for (i = 0; wine_main_preload_info[i].size != 0; i++)
-    {
-        /* Match how the preloader maps reserved areas: */
-        mmap(wine_main_preload_info[i].addr, wine_main_preload_info[i].size, PROT_NONE,
-             MAP_FIXED | MAP_NORESERVE | MAP_PRIVATE | MAP_ANON, -1, 0);
-    }
+    /* Mach-O zerofill sections WINE_RESERVE and WINE_TOP_DOWN are already
+     * mapped by dyld at process start. Calling mmap(MAP_FIXED, PROT_NONE)
+     * over them would overwrite existing pthread stacks with PROT_NONE and cause SIGBUS.
+     */
 }
 
 #else

--- a/loader/preloader_mac.c
+++ b/loader/preloader_mac.c
@@ -326,17 +326,25 @@ __ASM_GLOBAL_FUNC( start,
 #error preloader not implemented for this CPU
 #endif
 
-void wld_exit( int code ) __attribute__((noreturn));
-SYSCALL_NOERR( wld_exit, 1 /* SYS_exit */ );
+void wld_exit( int code )
+{
+    exit( code );
+}
 
-ssize_t wld_write( int fd, const void *buffer, size_t len );
-SYSCALL_FUNC( wld_write, 4 /* SYS_write */ );
+ssize_t wld_write( int fd, const void *buffer, size_t len )
+{
+    return write( fd, buffer, len );
+}
 
-void *wld_mmap( void *start, size_t len, int prot, int flags, int fd, off_t offset );
-SYSCALL_FUNC( wld_mmap, 197 /* SYS_mmap */ );
+void *wld_mmap( void *start, size_t len, int prot, int flags, int fd, off_t offset )
+{
+    return mmap( start, len, prot, flags, fd, offset );
+}
 
-void *wld_munmap( void *start, size_t len );
-SYSCALL_FUNC( wld_munmap, 73 /* SYS_munmap */ );
+int wld_munmap( void *start, size_t len )
+{
+    return munmap( start, len );
+}
 
 static intptr_t (*p_dyld_get_image_slide)( const struct target_mach_header* mh );
 

--- a/loader64/Makefile.in
+++ b/loader64/Makefile.in
@@ -3,18 +3,23 @@ PARENTSRC = ../loader
 SOURCES = \
 	main.c \
 	preloader.c \
-	preloader_mac.c
+	preloader_mac.c \
+	wine_info.plist.in
 
-PROGRAMS = wine64 wine64-preloader
-INSTALL_LIB = wine64 wine64-preloader
+PROGRAMS = $(WINELOADER_PROGRAMS)
+INSTALL_LIB = $(WINELOADER_PROGRAMS)
 UNIX_CFLAGS = -fPIE
 
 preloader_EXTRADEFS = -fno-builtin
+
+wine_OBJS = main.o
+wine_DEPS = $(WINELOADER_DEPENDS)
+wine_LDFLAGS = $(WINELOADER_LDFLAGS) $(LDEXECFLAGS) $(PTHREAD_LIBS)
 
 wine64_OBJS = main.o
 wine64_DEPS = $(WINELOADER_DEPENDS)
 wine64_LDFLAGS = $(WINELOADER_LDFLAGS) $(LDEXECFLAGS) $(PTHREAD_LIBS)
 
-wine64_preloader_OBJS = preloader.o
+wine64_preloader_OBJS = preloader.o preloader_mac.o
 wine64_preloader_DEPS = $(WINELOADER_DEPENDS)
 wine64_preloader_LDFLAGS = $(WINEPRELOADER_LDFLAGS)

--- a/server/fsync.c
+++ b/server/fsync.c
@@ -310,7 +310,12 @@ int fsync_grab_shm_idx( unsigned int shm_idx )
 
 static inline int futex_wake( int *addr, int val )
 {
+#ifdef __linux__
     return syscall( __NR_futex, addr, 1, val, NULL, 0, 0 );
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
 }
 
 /* shm layout for events or event-like objects. */

--- a/server/ntsync_tmp.h
+++ b/server/ntsync_tmp.h
@@ -8,7 +8,17 @@
 #ifndef __LINUX_NTSYNC_H
 #define __LINUX_NTSYNC_H
 
+#include <sys/ioctl.h>
+
+#ifdef HAVE_LINUX_TYPES_H
 #include <linux/types.h>
+#elif defined(__linux__)
+#include <linux/types.h>
+#else
+#include <stdint.h>
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+#endif
 
 struct ntsync_sem_args {
 	__u32 count;

--- a/server/token.c
+++ b/server/token.c
@@ -220,6 +220,19 @@ void init_user_sid(void)
     size_t n;
     FILE *f;
 
+#ifdef __APPLE__
+    uuid_t mac_uuid;
+    struct timespec timeout = { 1, 0 };
+    if (gethostuuid( mac_uuid, &timeout ) == 0)
+    {
+        uint64_t *p = (uint64_t *)mac_uuid;
+        local_user_sid.sub_auth[1] = (unsigned int)(p[0] >> 32);
+        local_user_sid.sub_auth[2] = (unsigned int)p[0];
+        local_user_sid.sub_auth[3] = getuid();
+        return;
+    }
+#endif
+
     f = fopen( "/etc/machine-id", "r" );
     if (!f)
     {


### PR DESCRIPTION
### Overview

This PR fixes macOS compilation and runtime failures under Rosetta 2 for Wine:
- **Rosetta 2 raw syscall trap resolution**: Replaced raw user-space BSD assembly syscalls (`wld_exit`, `wld_write`, `wld_mmap`, `wld_munmap`) in `loader/preloader_mac.c` with C runtime library calls to resolve `SIGBUS` crashes.
- **Header portability**: Guarded `<linux/types.h>` with `#ifdef __linux__` in `server/ntsync_tmp.h` and `dlls/ntdll/unix/ntsync_tmp.h` for Darwin builds.
- **Loader64 build rules**: Updated `loader64/Makefile.in` to define `wine_OBJS`, `wine_DEPS`, `wine_LDFLAGS`, and add `preloader_mac.o` and `wine_info.plist.in`.
- **TEB %gs setting on macOS**: Implemented `_thread_set_tsd_base` in `signal_x86_64.c` for macOS thread TEB initialization.